### PR TITLE
Implement TypeDoc publications on release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 [Unreleased]: https://github.com/atomist/atomist-sdm/compare/0.1.1...HEAD
 
+### Added
+
+-   Publish TypeDoc when Node project is released
+-   Increment version after release
+
 ## [0.1.1][] - 2018-05-10
 
 [0.1.1]: https://github.com/atomist/atomist-sdm/compare/0.1.0...0.1.1

--- a/src/machine/nodeSupport.ts
+++ b/src/machine/nodeSupport.ts
@@ -59,15 +59,20 @@ import {
     ProductionDeploymentGoal,
     PublishGoal,
     ReleaseDockerGoal,
+    ReleaseDocsGoal,
     ReleaseNpmGoal,
     ReleaseTagGoal,
+    ReleaseVersionGoal,
     StagingDeploymentGoal,
 } from "./goals";
 import {
     DockerReleasePreparations,
+    DocsReleasePreparations,
     executeReleaseDocker,
+    executeReleaseDocs,
     executeReleaseNpm,
     executeReleaseTag,
+    executeReleaseVersion,
     NpmReleasePreparations,
 } from "./release";
 
@@ -110,13 +115,15 @@ export function addNodeSupport(sdm: SoftwareDeliveryMachine, configuration: Conf
                 }), { pushTest: IsNode })
         .addGoalImplementation("nodeDockerRelease", ReleaseDockerGoal,
             executeReleaseDocker(sdm.opts.projectLoader,
-                NodeProjectIdentifier,
                 DockerReleasePreparations,
                 {
                     ...configuration.sdm.docker.hub as DockerOptions,
                 }), { pushTest: allSatisfied(IsNode, hasFile("Dockerfile")) })
-        .addGoalImplementation("tagRelease", ReleaseTagGoal,
-            executeReleaseTag(sdm.opts.projectLoader));
+        .addGoalImplementation("tagRelease", ReleaseTagGoal, executeReleaseTag(sdm.opts.projectLoader))
+        .addGoalImplementation("nodeDocsRelease", ReleaseDocsGoal,
+            executeReleaseDocs(sdm.opts.projectLoader, DocsReleasePreparations), { pushTest: IsNode })
+        .addGoalImplementation("nodeVersionRelease", ReleaseVersionGoal,
+            executeReleaseVersion(sdm.opts.projectLoader, NodeProjectIdentifier), { pushTest: IsNode });
 
     sdm.goalFulfillmentMapper
         .addSideEffect({


### PR DESCRIPTION
Publish goals added "release" phase of goal sets.  Use original
project to create new project rooted at TypeDoc output directory.
Initialize Git repository there, commit, and force push to gh-pages
branch.  Might be useful in the future to harmonize the command
execution interfaces spread between automation-client and sdm.

Set targetUrl for release tag to the tagged release on GitHub.com.

Also add incrementing version after release.  Had to checkout and pull
origin/master.  Add abstraction around a logging executor so spawn
and git operations could be interleaved and properly logged and
short-circuited if a command fails.

Closes atomist/sdm#378