### PR TITLE
Added smoke test goal

### DIFF
--- a/src/machine/goals.ts
+++ b/src/machine/goals.ts
@@ -115,6 +115,17 @@ export const ReleaseVersionGoal = new GoalWithPrecondition({
     failedDescription: "Incrementing version failure",
 }, ReleaseDocsGoal);
 
+export const SmokeTestGoal = new GoalWithPrecondition({
+    uniqueName: "SmokeTest",
+    environment: ProductionEnvironment,
+    orderedName: "3-smoke-test",
+    displayName: "smoke test",
+    workingDescription: "Running smoke tests...",
+    completedDescription: "Run smoke tests",
+    failedDescription: "Smoke test failure",
+    isolated: true,
+}, BuildGoal);
+
 // GOALSET Definition
 
 // Just running review and autofix
@@ -210,6 +221,7 @@ export const StagingKubernetesDeployGoals = new Goals(
     PublishGoal,
     DockerBuildGoal,
     TagGoal,
+    SmokeTestGoal,
     new GoalWithPrecondition({ ...StagingDeploymentGoal.definition, approvalRequired: false }, ...StagingDeploymentGoal.dependsOn),
 );
 

--- a/src/machine/nodeSupport.ts
+++ b/src/machine/nodeSupport.ts
@@ -18,6 +18,7 @@ import {
     Configuration,
     logger,
 } from "@atomist/automation-client";
+import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import { GitProject } from "@atomist/automation-client/project/git/GitProject";
 import {
     allSatisfied,
@@ -66,7 +67,7 @@ import {
     ReleaseDocsGoal,
     ReleaseNpmGoal,
     ReleaseTagGoal,
-    ReleaseVersionGoal,
+    ReleaseVersionGoal, SmokeTestGoal,
     StagingDeploymentGoal,
 } from "./goals";
 import {
@@ -79,6 +80,7 @@ import {
     executeReleaseVersion,
     NpmReleasePreparations,
 } from "./release";
+import {executeSmokeTests} from "./smokeTest";
 
 /**
  * Add Node.js implementations of goals to SDM.
@@ -122,6 +124,12 @@ export function addNodeSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMa
                 {
                     ...sdm.configuration.sdm.npm as NpmOptions,
                 }), { pushTest: IsNode })
+        .addGoalImplementation("nodeSmokeTest", SmokeTestGoal,
+            executeSmokeTests(sdm.configuration.sdm.projectLoader, {
+                team: "AHF8B2MBL",
+                org: "sample-sdm-fidelity",
+                }, new GitHubRepoRef("atomist", "sdm-smoke-test"),
+            ), { pushTest: IsNode })
         .addGoalImplementation("nodeDockerRelease", ReleaseDockerGoal,
             executeReleaseDocker(sdm.configuration.sdm.projectLoader,
                 DockerReleasePreparations,

--- a/src/machine/nodeSupport.ts
+++ b/src/machine/nodeSupport.ts
@@ -67,7 +67,8 @@ import {
     ReleaseDocsGoal,
     ReleaseNpmGoal,
     ReleaseTagGoal,
-    ReleaseVersionGoal, SmokeTestGoal,
+    ReleaseVersionGoal,
+    SmokeTestGoal,
     StagingDeploymentGoal,
 } from "./goals";
 import {

--- a/src/machine/smokeTest.ts
+++ b/src/machine/smokeTest.ts
@@ -22,10 +22,11 @@ import {GitProject} from "@atomist/automation-client/project/git/GitProject";
 import {
     ExecuteGoalResult, ExecuteGoalWithLog, ProgressLog, ProjectLoader, RunWithLogContext,
 } from "@atomist/sdm";
-import {ChildProcessResult, spawnAndWatch} from "@atomist/sdm/util/misc/spawned";
 
 import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
 import {GitCommandGitProject} from "@atomist/automation-client/project/git/GitCommandGitProject";
+import {ChildProcessResult} from "@atomist/automation-client/util/spawned";
+import {spawnAndWatch} from "@atomist/sdm/api-helper/misc/spawned";
 import * as child_process from "child_process";
 import {ChildProcess} from "child_process";
 
@@ -64,7 +65,7 @@ export function executeSmokeTests(
                 message: testResult.message,
                 targetUrl: rwlc.progressLog.url,
             };
-            rwlc.progressLog.write(`Smoke tests comple: ${egr}`);
+            rwlc.progressLog.write(`Smoke tests complete: ${egr}`);
             return egr;
         });
     };
@@ -127,7 +128,7 @@ function flushLog(progressLog: ProgressLog) {
 function installAndBuild(targetName: string, progressLog: ProgressLog, baseDir: string) {
     progressLog.write(`Installing ${targetName}...`);
     flushLog(progressLog);
-    const npmInstallResult = executeCommandAndBlock(baseDir, `npm i`);
+    const npmInstallResult = executeCommandAndBlock(baseDir, `npm ci`);
     progressLog.write(npmInstallResult);
 
     progressLog.write(`Building ${targetName} ...`);

--- a/src/machine/smokeTest.ts
+++ b/src/machine/smokeTest.ts
@@ -61,18 +61,6 @@ export function executeSmokeTests(
             flushLog(rwlc.progressLog);
             sdmProcess.kill();
 
-            if (id.sha) {
-                await createStatus(
-                    (credentials as TokenCredentials).token,
-                    id as GitHubRepoRef,
-                    {
-                        context: "npm/atomist/smoketest",
-                        description: "smokeTest",
-                        target_url: rwlc.progressLog.url,
-                        state: testResult.error ? "failure" : "success",
-                    });
-            }
-
             const egr: ExecuteGoalResult = {
                 code: testResult.code,
                 message: testResult.message,

--- a/src/machine/smokeTest.ts
+++ b/src/machine/smokeTest.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-
 import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import {
     ProjectOperationCredentials,

--- a/src/machine/smokeTest.ts
+++ b/src/machine/smokeTest.ts
@@ -1,0 +1,140 @@
+
+import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
+import {
+    ProjectOperationCredentials,
+    TokenCredentials,
+} from "@atomist/automation-client/operations/common/ProjectOperationCredentials";
+import {GitProject} from "@atomist/automation-client/project/git/GitProject";
+import {
+    ExecuteGoalResult, ExecuteGoalWithLog, ProgressLog, ProjectLoader, RunWithLogContext,
+} from "@atomist/sdm";
+import {createStatus} from "@atomist/sdm/util/github/ghub";
+import {ChildProcessResult, spawnAndWatch} from "@atomist/sdm/util/misc/spawned";
+
+import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";
+import {GitCommandGitProject} from "@atomist/automation-client/project/git/GitCommandGitProject";
+import * as child_process from "child_process";
+import {ChildProcess} from "child_process";
+
+const localAtomistAdminPassword = "atomist123";
+
+export interface SmokeTestTarget {
+    team: string;
+    org: string;
+}
+
+export function executeSmokeTests(
+    projectLoader: ProjectLoader,
+    smokeTestTarget: SmokeTestTarget,
+    smokeTestRepo: RemoteRepoRef,
+): ExecuteGoalWithLog {
+
+    return async (rwlc: RunWithLogContext): Promise<ExecuteGoalResult> => {
+        const { credentials, id, context } = rwlc;
+
+        return projectLoader.doWithProject({ credentials, id, context, readOnly: false },
+            async (project: GitProject) => {
+
+            const sdmProcess = startSdm(project.baseDir, rwlc.progressLog);
+
+            // how to know when sdm is started? timeout is a hack
+            await new Promise<any>(res => setTimeout(res, 10000));
+
+            const testResult = await runSmokeTests(smokeTestTarget, smokeTestRepo, rwlc.progressLog, credentials);
+
+            rwlc.progressLog.write(`Stopping SDM`);
+            flushLog(rwlc.progressLog);
+            sdmProcess.kill();
+
+            if (id.sha) {
+                await createStatus(
+                    (credentials as TokenCredentials).token,
+                    id as GitHubRepoRef,
+                    {
+                        context: "npm/atomist/smoketest",
+                        description: "smokeTest",
+                        target_url: rwlc.progressLog.url,
+                        state: testResult.error ? "failure" : "success",
+                    });
+            }
+
+            const egr: ExecuteGoalResult = {
+                code: testResult.code,
+                message: testResult.message,
+                targetUrl: rwlc.progressLog.url,
+            };
+            rwlc.progressLog.write(`Smoke tests comple: ${egr}`);
+            return egr;
+        });
+    };
+}
+
+function startSdm(baseDir: string, progressLog: ProgressLog): ChildProcess {
+    installAndBuild("SDM", progressLog, baseDir);
+    process.env.LOCAL_ATOMIST_ADMIN_PASSWORD = localAtomistAdminPassword;
+    progressLog.write(`Starting SDM...`);
+    flushLog(progressLog);
+    const runningSdm = child_process.spawn("node",
+        ["node_modules/@atomist/automation-client/start.client.js"],
+        {cwd: baseDir, env: process.env});
+    progressLog.write(`Started SDM with PID=${runningSdm.pid}`);
+    flushLog(progressLog);
+
+    runningSdm.stdout.on("data", data => {
+        progressLog.write(data.toString());
+    });
+    runningSdm.stderr.on("data", data => {
+        progressLog.write(data.toString());
+    });
+    runningSdm.on("close", (code: number, signal: string) => { progressLog.write(`close ${code} ${signal}`); });
+    runningSdm.on("disconnect", () => { progressLog.write(`disconnect`); });
+    runningSdm.on("error", (err: Error) => { progressLog.write(`error ${err.message}`); });
+    runningSdm.on("exit", (code: number, signal: string) => { progressLog.write(`exit ${code} ${signal}`); });
+    runningSdm.on("message", (message: any, sendHandle) => { progressLog.write(`message ${message} ${sendHandle}`); });
+    return runningSdm;
+}
+
+async function runSmokeTests(target: SmokeTestTarget, repo: RemoteRepoRef, progressLog: ProgressLog,
+                             credentials: ProjectOperationCredentials): Promise<ChildProcessResult> {
+    progressLog.write(`Cloning ${repo.owner}:${repo.repo}`);
+    flushLog(progressLog);
+    const smokeTestProject = await GitCommandGitProject.cloned(credentials, repo);
+    progressLog.write(`Cloned ${repo.owner}:${repo.repo} to ${smokeTestProject.baseDir}`);
+    installAndBuild("Smoke Tests", progressLog, smokeTestProject.baseDir);
+
+    progressLog.write(`Smoke testing...`);
+    process.env.LOCAL_ATOMIST_ADMIN_PASSWORD = localAtomistAdminPassword;
+    process.env.GITHUB_TOKEN = (credentials as TokenCredentials).token;
+    process.env.ATOMIST_TEAMS = target.team;
+    process.env.SMOKETEST_ORG = target.org;
+
+    const result = await spawnAndWatch({
+        command: "npm",
+        args: [
+            "run",
+            "test:cucumber",
+        ],
+    }, { cwd: smokeTestProject.baseDir }, progressLog);
+    return result;
+}
+
+function flushLog(progressLog: ProgressLog) {
+    // tslint:disable-next-line:no-floating-promises
+    progressLog.flush();
+}
+
+function installAndBuild(targetName: string, progressLog: ProgressLog, baseDir: string) {
+    progressLog.write(`Installing ${targetName}...`);
+    flushLog(progressLog);
+    const npmInstallResult = executeCommandAndBlock(baseDir, `npm i`);
+    progressLog.write(npmInstallResult);
+
+    progressLog.write(`Building ${targetName} ...`);
+    flushLog(progressLog);
+    const npmBuildResult = executeCommandAndBlock(baseDir, `npm run build`);
+    progressLog.write(npmBuildResult);
+}
+
+function executeCommandAndBlock(cwd: string, command: string): string {
+    return child_process.execSync(command, {cwd, env: process.env}).toString();
+}

--- a/src/machine/smokeTest.ts
+++ b/src/machine/smokeTest.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import {

--- a/src/machine/smokeTest.ts
+++ b/src/machine/smokeTest.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import {GitHubRepoRef} from "@atomist/automation-client/operations/common/GitHubRepoRef";
 import {
     ProjectOperationCredentials,
     TokenCredentials,
@@ -23,7 +22,6 @@ import {GitProject} from "@atomist/automation-client/project/git/GitProject";
 import {
     ExecuteGoalResult, ExecuteGoalWithLog, ProgressLog, ProjectLoader, RunWithLogContext,
 } from "@atomist/sdm";
-import {createStatus} from "@atomist/sdm/util/github/ghub";
 import {ChildProcessResult, spawnAndWatch} from "@atomist/sdm/util/misc/spawned";
 
 import {RemoteRepoRef} from "@atomist/automation-client/operations/common/RepoId";


### PR DESCRIPTION
addNodeSupport.ts line 127 seems like a strange place to associate the repo that contains the smoke tests and the team that I  want  it to run in. Mainly because the  choice to  tie this goal to sample-sdm  happens in machine.ts line 101, and it is tied to StagingKubernetesDeployGoals which doesn't seem like it should be specific for sample-sdm.

I  don't know  what token  this will get when running, but it needs access to team AHF8B2MBL.

I run the sdm with child_process.spawn (rather than spawnAndWatch) so that I can run the smoke tests on it, and then kill it.There may  be better ways to do this.

I clone the smoke tests with GitCommandGitProject.cloned rather than the  project loader to avoid nesting doWithProject (which seems wierd but may  be fine) and to simplify handling the result. This won't handle smoke tests on BitBucket, so I should probably change this at some point.

I've run executeSmokeTests directly, but did not check in the test because it contained a token. I don't know how that could be committed to the project, the test also does a lot of real I/O and is time consuming. I haven't tested it in the context of a running atomist-sdm (specifically to ensure that StagingKubernetesDeployGoals executes with  this step  properly).

It currently adds a GitHub status to the commit if there is a sha. I can add specific notifications (to the channel associated with the sdm), or the user who made the commit.

These will  currently be run for a new push, but might need to be run continuously to ensure that everything is currently running  properly. It should probably get kicked off when the smoke tests change as well.

When tests fail, there may have been a change in the sdm, a  change in the  smoke tests, neither changed, or both.
If neither changed, and we are running the tests on an interval then we can assume a runtime issue (a service may be down, good info when about to run a demo).
If both changed then we don't really have any info about the cause.
A change to the sdm or the test hints at a root cause, and we could call out the author of  the commit specifically, espcially if the tests consistently fail afterward. If it is still failing for the next commit,  then it would be nice to let that author know that it was already failing (espcially if it failed in the same way).