### PR TITLE
Exclude *.d.ts from adding license headers

### DIFF
--- a/lib/autofix/addAtomistHeader.ts
+++ b/lib/autofix/addAtomistHeader.ts
@@ -35,8 +35,7 @@ export function addAtomistHeader(name: string,
                                  pushTest: PushTest): AutofixRegistration<AddHeaderParameters> {
     const parametersInstance = new AddHeaderParameters();
     parametersInstance.glob = glob;
-    // Stop it continually editing the barrel and graphql types
-    parametersInstance.excludeGlob = "src/{typings/types,index}.ts";
+    parametersInstance.excludeGlob = "**/*.d.ts";
     return {
         name,
         pushTest: allSatisfied(pushTest, hasFileContaining(LicenseFilename, /Apache License/)),


### PR DESCRIPTION
Update the addAtomistHeader exclude pattern to exclude .d.ts files and
remove the exclusion of index.ts and types.ts since the proper fix for
those, and the one that has been implemented, is to generate those
files as part of the build and not include them in source code.  The
pattern that was there no longer worked due to the migration from src
to lib.

Closes #43