### PR TITLE
Make update support files a code transform command

### DIFF
--- a/lib/autofix/addHeader.ts
+++ b/lib/autofix/addHeader.ts
@@ -57,7 +57,6 @@ export class AddHeaderParameters extends RequestedCommitParameters {
     }
 }
 
-/* tslint:disable */
 export const ApacheHeader = `/*
  * Copyright © 2018 Atomist, Inc.
  *
@@ -84,7 +83,7 @@ export const AddApacheLicenseTransform: CodeTransformRegistration<AddHeaderParam
 export async function addHeaderTransform(p: Project,
                                          ci: ParametersInvocation<AddHeaderParameters>): Promise<Project> {
 
-    let filesWithDifferentHeaders: any[] = [];
+    const filesWithDifferentHeaders: any[] = [];
     await projectUtils.doWithFiles(p, ci.parameters.glob, async f => {
         if (ci.parameters.excludeGlob && minimatch(f.path, ci.parameters.excludeGlob)) {
             return;
@@ -106,15 +105,18 @@ export async function addHeaderTransform(p: Project,
 
 /**
  * There are some lines that really need to be at the top.
- * 
+ *
  * If a file starts with '#!/executable/to/run', leave that at the top.
  * It's invalid to put a comment before it.
- * @param content 
+ * @param content to extract sh-bang line from
+ * @return two-element array, the first element if the sh-bang line or
+ *         an empty string if there is no sh-bang line, the second element
+ *         is the rest of the content.
  */
 function separatePrefixLines(content: string): [string, string] {
     if (content.startsWith("#!")) {
         const lines = content.split("\n");
-        return [lines[0] + "\n", lines.slice(1).join("\n")]
+        return [lines[0] + "\n", lines.slice(1).join("\n")];
     }
     return ["", content];
 }

--- a/lib/machine/nodeSupport.ts
+++ b/lib/machine/nodeSupport.ts
@@ -46,6 +46,7 @@ import {
     RenameTest,
     RenameTestFix,
 } from "../autofix/test/testNamingFix";
+import { UpdateSupportFilesTransform } from "../autofix/updateSupportFiles";
 import { deleteDistTagOnBranchDeletion } from "../event/deleteDistTagOnBranchDeletion";
 import { AutomationClientTagger } from "../support/tagger";
 import { RewriteImports } from "../transform/rewriteImports";
@@ -183,6 +184,7 @@ export function addNodeSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMa
         .addCodeTransformCommand(UpdatePackageVersion)
         .addCodeTransformCommand(TryToUpdateAtomistPeerDependencies)
         .addCodeTransformCommand(UpdatePackageAuthor)
+        .addCodeTransformCommand(UpdateSupportFilesTransform)
         .addCodeTransformCommand(RewriteImports)
         .addCodeTransformCommand(RenameTest);
 

--- a/lib/machine/teamPolicies.ts
+++ b/lib/machine/teamPolicies.ts
@@ -40,9 +40,7 @@ import * as _ from "lodash";
 import {
     AddCommunityFiles,
 } from "../autofix/addCommunityFiles";
-import {
-    UpdateSupportFiles,
-} from "../autofix/updateSupportFiles";
+// import { UpdateSupportFilesFix } from "../autofix/updateSupportFiles";
 import {
     autofix,
     pushImpact,
@@ -71,7 +69,7 @@ export function addTeamPolicies(sdm: SoftwareDeliveryMachine<SoftwareDeliveryMac
     });
 
     autofix.with(AddCommunityFiles);
-    autofix.with(UpdateSupportFiles);
+    // autofix.with(UpdateSupportFilesFix);
 }
 
 async function warnAboutLowercaseCommitTitles(sdm: SoftwareDeliveryMachine,


### PR DESCRIPTION
Disable autofix for now and register the update support files
transform to a command.  I did not implement running `tslint --fix`
after updating the file because the tslint autofix should still do
that.  Will this result in a PR that automatically merges if the
resulting goal set completes successfully?