### PR TITLE
Move TSLint from build step to code inspection

### DIFF
--- a/lib/inspection/reviewComments.ts
+++ b/lib/inspection/reviewComments.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ReviewComment,
+} from "@atomist/automation-client";
+import {
+    PushImpactResponse,
+    ReviewListener,
+    ReviewListenerRegistration,
+} from "@atomist/sdm";
+
+/**
+ * Return true if there are any review comments with a severity of "error".
+ * @param rli invocation with all comments
+ * @return true if any comments have severity "error", false otherwise
+ */
+export function errorsExistReviewListener(pirIfError: PushImpactResponse): ReviewListener {
+    return async rli => {
+        if (rli && rli.review && rli.review.comments && rli.review.comments.some(c => c.severity === "error")) {
+            return pirIfError;
+        }
+        return PushImpactResponse.proceed;
+    };
+}
+
+/**
+ * Listener that fails the code inspection if the review has any
+ * error comments.
+ */
+export const FailGoalIfErrorComments: ReviewListenerRegistration = {
+    name: "Fail goal if any code inspections result in comments with severity error",
+    listener: errorsExistReviewListener(PushImpactResponse.failGoals),
+};
+
+/**
+ * Listener that requires approval on the code inspection if the
+ * review has any error comments.
+ */
+export const ApproveGoalIfErrorComments: ReviewListenerRegistration = {
+    name: "Require approval if any code inspections result in comments with severity error",
+    listener: errorsExistReviewListener(PushImpactResponse.requireApprovalToProceed),
+};
+
+/* tslint:disable:cyclomatic-complexity */
+/**
+ * Function suitable for use by Array.prototype.sort() to sort review
+ * comments by severity, category, subcategory, and sourceLocation
+ * path and offset.  Items with the same severity, category, and
+ * subcategory without a location are sorted before those having a
+ * location.
+ *
+ * @param a First element to compare.
+ * @param b Second element to compare.
+ * @return -1 if a sorts first, 1 if b sorts first, and 0 if they are equivalent.
+ */
+export function reviewCommentSorter(a: ReviewComment, b: ReviewComment): number {
+    if (a.severity !== b.severity) {
+        const severities = ["error", "warn", "info"];
+        for (const severity of severities) {
+            if (a.severity === severity) {
+                return -1;
+            } else if (b.severity === severity) {
+                return 1;
+            }
+        }
+    }
+    if (a.category !== b.category) {
+        return a.category.localeCompare(b.category);
+    }
+    if (a.subcategory !== b.subcategory) {
+        return a.subcategory.localeCompare(b.subcategory);
+    }
+    if (!a.sourceLocation && b.sourceLocation) {
+        return -1;
+    } else if (a.sourceLocation && !b.sourceLocation) {
+        return 1;
+    } else {
+        if (a.sourceLocation.path !== b.sourceLocation.path) {
+            return a.sourceLocation.path.localeCompare(b.sourceLocation.path);
+        } else {
+            return a.sourceLocation.offset - b.sourceLocation.offset;
+        }
+    }
+    return 0;
+}
+/* tslint:enable:cyclomatic-complexity */

--- a/lib/inspection/tslint.ts
+++ b/lib/inspection/tslint.ts
@@ -1,0 +1,183 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    isLocalProject,
+    logger,
+    NoParameters,
+    Project,
+    ProjectReview,
+    ReviewComment,
+    safeExec,
+    Severity,
+    SourceLocation,
+} from "@atomist/automation-client";
+import {
+    CodeInspection,
+    CodeInspectionRegistration,
+    PushImpactResponse,
+    ReviewListener,
+    ReviewListenerRegistration,
+} from "@atomist/sdm";
+import * as appRoot from "app-root-path";
+import * as path from "path";
+
+export interface TslintPosition {
+    character: number;
+    line: number;
+    position: number;
+}
+
+export interface TslintFix {
+    innerStart: number;
+    innerLength: number;
+    innerText: string;
+}
+
+/**
+ * Manually created interface representing the JSON output of the
+ * tslint command-line utility.
+ */
+export interface TslintResult {
+    endPosition: TslintPosition;
+    failure: string;
+    fix: TslintFix | TslintFix[];
+    name: string;
+    ruleName: string;
+    ruleSeverity: "ERROR" | "WARNING";
+    startPosition: TslintPosition;
+}
+
+export type TslintResults = TslintResult[];
+
+/**
+ * Return a review comment for a TSLint violation.
+ */
+function tslintReviewComment(detail: string, severity: Severity = "error", sourceLocation?: SourceLocation): ReviewComment {
+    return {
+        severity,
+        detail,
+        category: "lint",
+        subcategory: "tslint",
+        sourceLocation,
+    };
+}
+
+/**
+ * Convert the JSON output of TSLint to proper ReviewComments.  If any
+ * part of the process fails, an empty array is returned.
+ *
+ * @param tslintOutput string output from running `tslint` that will be parsed and converted.
+ * @return TSLint errors and warnings as ReviewComments
+ */
+export function mapTslintResultsToReviewComments(tslintOutput: string, dir: string): ReviewComment[] {
+    let results: TslintResults;
+    try {
+        results = JSON.parse(tslintOutput);
+    } catch (e) {
+        logger.error(`Failed to parse TSLint output '${tslintOutput}': ${e.message}`);
+        return [];
+    }
+
+    const comments = results.map(r => {
+        const comment = tslintReviewComment(r.failure, (r.ruleSeverity === "ERROR") ? "error" : "warn", {
+            path: r.name.replace(dir + path.sep, ""),
+            offset: r.startPosition.position,
+            columnFrom1: r.startPosition.character + 1,
+            lineFrom1: r.startPosition.line + 1,
+        });
+        return comment;
+    });
+    return comments;
+}
+
+/**
+ * Run TSLint on a project with a tslint.json file, using the standard
+ * version of TSLint and its configuration, i.e., the ones in this
+ * project.  At most 20 TSLint violations are returned, since they are
+ * used to create a GitHub issue and if the body of that POST is too
+ * large, it is rejected.
+ */
+export const RunTslintOnProject: CodeInspection<ProjectReview, NoParameters> = async (p: Project) => {
+    const review: ProjectReview = { repoId: p.id, comments: [] };
+    const tslintJson = "tslint.json";
+    const tslintConfigFile = await p.getFile(tslintJson);
+    if (!tslintConfigFile) {
+        return review;
+    }
+    const baseDir = appRoot.path;
+    const tslintExe = path.join(baseDir, "node_modules", ".bin", "tslint");
+    const tslintConfig = path.join(baseDir, tslintJson);
+
+    if (!isLocalProject(p)) {
+        logger.error(`Project ${p.name} is not a local project`);
+        return review;
+    }
+    const cwd = p.baseDir;
+    logger.debug(`Running ${tslintExe} using ${tslintConfig} on ${p.name} in ${cwd}`);
+    const tslintArgs = [
+        "--config", tslintConfig,
+        "--format", "json",
+        "--project", cwd,
+        "--force",
+    ];
+    try {
+        const tslintResult = await safeExec(tslintExe, tslintArgs, { cwd });
+        if (tslintResult.stderr) {
+            logger.debug(`TSLint standard error: ${tslintResult.stderr}`);
+        }
+        const comments = mapTslintResultsToReviewComments(tslintResult.stdout, p.baseDir);
+        const maxComments = 20;
+        if (comments.length > maxComments) {
+            const remove = comments.length - maxComments;
+            const more = tslintReviewComment(`${remove} additional errors and/or warnings were omitted from this report`);
+            comments.splice(maxComments, remove, more);
+        }
+        review.comments.push(...comments);
+    } catch (e) {
+        logger.error(`Failed to run TSLint: ${e.message}`);
+    }
+
+    return review;
+};
+
+/**
+ * Provide a code inspection that runs TSLint and returns a
+ * ProjectReview.
+ */
+export const RunTslint: CodeInspectionRegistration<ProjectReview, NoParameters> = {
+    name: "RunTSLint",
+    description: "Run TSLint on project",
+    inspection: RunTslintOnProject,
+    intent: "tslint",
+};
+
+/**
+ * Listener that fails the code inspection if the review has any
+ * error comments.
+ */
+export const failGoalsIfErrorCommentsReviewListener: ReviewListener = async rli => {
+    if (rli && rli.review && rli.review.comments && rli.review.comments.some(c => c.severity === "error")) {
+        logger.debug(`Failing auto code inspection due to error review comments`);
+        return PushImpactResponse.failGoals;
+    }
+    return PushImpactResponse.proceed;
+};
+
+export const FailGoalsIfErrorComments: ReviewListenerRegistration = {
+    name: "Fail Goals if any code inspections result in comments with severity error",
+    listener: failGoalsIfErrorCommentsReviewListener,
+};

--- a/lib/machine/goals.ts
+++ b/lib/machine/goals.ts
@@ -140,25 +140,22 @@ export const CheckGoals = goals("Check")
 
 // Goals for running in local mode
 export const LocalGoals = goals("Local Build")
-    .plan(CheckGoals)
+    .plan(autofix, pushImpact, fingerprint)
     .plan(version).after(autofix)
-    .plan(build).after(autofix, version);
+    .plan(build).after(autofix, version)
+    .plan(autoCodeInspection).after(build);
 
 // Just running the build and publish
 export const BuildGoals = goals("Build")
-    .plan(CheckGoals)
-    .plan(version).after(autofix)
-    .plan(build).after(autofix, version)
+    .plan(LocalGoals)
     .plan(tag, publish).after(build);
 
 // Just running the build and publish
 export const BuildReleaseGoals = goals("Build with Release")
-    .plan(CheckGoals)
-    .plan(version).after(autofix)
-    .plan(build).after(autofix, version)
+    .plan(LocalGoals)
     .plan(tag).after(build)
     .plan(publishWithApproval).after(build)
-    .plan(releaseNpm, releaseDocs, releaseVersion).after(publishWithApproval)
+    .plan(releaseNpm, releaseDocs, releaseVersion).after(publishWithApproval, autoCodeInspection)
     .plan(releaseChangelog).after(releaseVersion)
     .plan(releaseTag).after(releaseNpm);
 
@@ -173,13 +170,11 @@ export const DockerGoals = goals("Docker Build")
 
 // Build including docker build
 export const DockerReleaseGoals = goals("Docker Build with Release")
-    .plan(CheckGoals)
-    .plan(version).after(autofix)
-    .plan(build).after(autofix, version)
+    .plan(LocalGoals)
     .plan(dockerBuild).after(build)
     .plan(tag).after(dockerBuild)
     .plan(publishWithApproval).after(build, dockerBuild)
-    .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(publishWithApproval)
+    .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(publishWithApproval, autoCodeInspection)
     .plan(releaseChangelog).after(releaseVersion)
     .plan(releaseTag, releaseHomebrew).after(releaseNpm, releaseDocker);
 
@@ -187,7 +182,7 @@ export const DockerReleaseGoals = goals("Docker Build with Release")
 export const KubernetesDeployGoals = goals("Deploy")
     .plan(DockerGoals)
     .plan(stagingDeployment).after(dockerBuild)
-    .plan(productionDeployment).after(stagingDeployment)
+    .plan(productionDeployment).after(stagingDeployment, autoCodeInspection)
     .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(productionDeployment)
     .plan(releaseChangelog).after(releaseVersion)
     .plan(releaseTag).after(releaseNpm, releaseDocker);
@@ -195,7 +190,7 @@ export const KubernetesDeployGoals = goals("Deploy")
 // Docker build and testing and production kubernetes deploy
 export const SimplifiedKubernetesDeployGoals = goals("Simplified Deploy")
     .plan(DockerGoals)
-    .plan(productionDeploymentWithApproval).after(dockerBuild)
+    .plan(productionDeploymentWithApproval).after(dockerBuild, autoCodeInspection)
     .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(productionDeploymentWithApproval)
     .plan(releaseChangelog).after(releaseVersion)
     .plan(releaseTag).after(releaseNpm, releaseDocker);

--- a/lib/machine/k8Support.ts
+++ b/lib/machine/k8Support.ts
@@ -43,7 +43,7 @@ export function kubernetesDeploymentData(sdm: SoftwareDeliveryMachine): (g: SdmG
                 imagePullSecret: "atomistjfrog",
                 replicas: ns === "production" ? 3 : 1,
                 ...ingress,
-            } as any;
+            };
         });
     };
 }

--- a/lib/machine/nodeSupport.ts
+++ b/lib/machine/nodeSupport.ts
@@ -51,10 +51,8 @@ import {
 } from "../autofix/test/testNamingFix";
 import { UpdateSupportFilesTransform } from "../autofix/updateSupportFiles";
 import { deleteDistTagOnBranchDeletion } from "../event/deleteDistTagOnBranchDeletion";
-import {
-    FailGoalsIfErrorComments,
-    RunTslint,
-} from "../inspection/tslint";
+import { ApproveGoalIfErrorComments } from "../inspection/reviewComments";
+import { RunTslint } from "../inspection/tslint";
 import { AutomationClientTagger } from "../support/tagger";
 import { RewriteImports } from "../transform/rewriteImports";
 import { TryToUpdateAtomistDependencies } from "../transform/tryToUpdateAtomistDependencies";
@@ -122,7 +120,7 @@ export function addNodeSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMa
 
     autoCodeInspection.with(RunTslint)
         .withListener(singleIssuePerCategoryManaging("tslint", true, p => true))
-        .withListener(FailGoalsIfErrorComments);
+        .withListener(ApproveGoalIfErrorComments);
 
     publish.with({
         ...NodeDefaultOptions,

--- a/lib/machine/nodeSupport.ts
+++ b/lib/machine/nodeSupport.ts
@@ -26,6 +26,9 @@ import {
     DockerOptions,
 } from "@atomist/sdm-pack-docker";
 import {
+    singleIssuePerCategoryManaging,
+} from "@atomist/sdm-pack-issue";
+import {
     executePublish,
     IsNode,
     nodeBuilder,
@@ -48,6 +51,10 @@ import {
 } from "../autofix/test/testNamingFix";
 import { UpdateSupportFilesTransform } from "../autofix/updateSupportFiles";
 import { deleteDistTagOnBranchDeletion } from "../event/deleteDistTagOnBranchDeletion";
+import {
+    FailGoalsIfErrorComments,
+    RunTslint,
+} from "../inspection/tslint";
 import { AutomationClientTagger } from "../support/tagger";
 import { RewriteImports } from "../transform/rewriteImports";
 import { TryToUpdateAtomistDependencies } from "../transform/tryToUpdateAtomistDependencies";
@@ -55,6 +62,7 @@ import { TryToUpdateAtomistPeerDependencies } from "../transform/tryToUpdateAtom
 import { UpdatePackageAuthor } from "../transform/updatePackageAuthor";
 import { UpdatePackageVersion } from "../transform/updatePackageVersion";
 import {
+    autoCodeInspection,
     autofix,
     build,
     dockerBuild,
@@ -107,10 +115,14 @@ export function addNodeSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMa
     build.with({
         ...NodeDefaultOptions,
         name: "npm-run-build",
-        builder: nodeBuilder("npm run build"),
+        builder: nodeBuilder("npm run compile", "npm test"),
         pushTest: NodeDefaultOptions.pushTest,
     })
         .withProjectListener(NodeModulesProjectListener);
+
+    autoCodeInspection.with(RunTslint)
+        .withListener(singleIssuePerCategoryManaging("tslint", true, p => true))
+        .withListener(FailGoalsIfErrorComments);
 
     publish.with({
         ...NodeDefaultOptions,

--- a/lib/machine/release.ts
+++ b/lib/machine/release.ts
@@ -528,7 +528,7 @@ export async function docsReleasePreparation(p: GitProject, gi: GoalInvocation):
             cwd: p.baseDir,
         },
         {
-            cmd: { command: "npm", args: ["run", "typedoc"] },
+            cmd: { command: "npm", args: ["run", "doc"] },
             cwd: p.baseDir,
         },
     ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -985,8 +985,7 @@
     "@types/highlight.js": {
       "version": "9.12.3",
       "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
-      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
-      "dev": true
+      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ=="
     },
     "@types/inquirer": {
       "version": "0.0.43",
@@ -1021,8 +1020,7 @@
     "@types/marked": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
-      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg==",
-      "dev": true
+      "integrity": "sha512-cDB930/7MbzaGF6U3IwSQp6XBru8xWajF5PV2YZZeV8DyiliTuld11afVztGI9+yJZ29il5E+NpGA6ooV/Cjkg=="
     },
     "@types/mime": {
       "version": "2.0.0",
@@ -1922,7 +1920,6 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
       "requires": {
         "chalk": "^1.1.3",
         "esutils": "^2.0.2",
@@ -1932,20 +1929,17 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
+          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "chalk": {
           "version": "1.1.3",
           "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
           "requires": {
             "ansi-styles": "^2.2.1",
             "escape-string-regexp": "^1.0.2",
@@ -1958,7 +1952,6 @@
           "version": "3.0.1",
           "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -1966,8 +1959,7 @@
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -2990,7 +2982,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
         "es5-ext": "^0.10.9"
@@ -3220,8 +3212,7 @@
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-      "dev": true
+      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA=="
     },
     "diff-match-patch": {
       "version": "1.0.4",
@@ -3335,7 +3326,7 @@
     },
     "enabled": {
       "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
+      "resolved": "http://registry.npmjs.org/enabled/-/enabled-1.0.2.tgz",
       "integrity": "sha1-ll9lE9LC0cX0ZStkouM5ZGf8L5M=",
       "requires": {
         "env-variable": "0.0.x"
@@ -3668,8 +3659,7 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
@@ -3998,7 +3988,7 @@
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
@@ -4032,7 +4022,7 @@
     },
     "fecha": {
       "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
+      "resolved": "http://registry.npmjs.org/fecha/-/fecha-2.3.3.tgz",
       "integrity": "sha512-lUGBnIamTAwk4znq5BcqsDaxSmZ9nDVJaij6NvRt/Tg4R69gERA+otPKbS86ROw9nxVMw2/mp1fnaiWqbs6Sdg=="
     },
     "figures": {
@@ -5142,7 +5132,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       },
@@ -5150,8 +5139,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         }
       }
     },
@@ -5318,12 +5306,11 @@
     "highlight.js": {
       "version": "9.13.1",
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.13.1.tgz",
-      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A==",
-      "dev": true
+      "integrity": "sha512-Sc28JNQNDzaH6PORtRLMvif9RSn1mYuOoX3omVjnb0+HbpPygU2ALBI0R/wsiqCb4/fcp07Gdo8g+fhtFrQl6A=="
     },
     "hoek": {
       "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "resolved": "http://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
       "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
     },
     "hosted-git-info": {
@@ -5947,8 +5934,7 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.12.0",
@@ -6474,8 +6460,7 @@
     "marked": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
-      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
-      "dev": true
+      "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw=="
     },
     "marked-terminal": {
       "version": "3.1.1",
@@ -10593,8 +10578,7 @@
     "progress": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.1.tgz",
-      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg==",
-      "dev": true
+      "integrity": "sha512-OE+a6vzqazc+K6LxJrX5UPyKFvGnL5CYmq2jFGNIBWHpc4QyE49/YOumcrpQFJpfejmvRtbJzgO1zPmMCqlbBg=="
     },
     "promise": {
       "version": "7.3.1",
@@ -11172,7 +11156,7 @@
     },
     "safe-regex": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
       "dev": true,
       "requires": {
@@ -11929,7 +11913,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
     "strip-json-comments": {
@@ -12322,7 +12306,6 @@
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.11.0.tgz",
       "integrity": "sha1-mPMMAurjzecAYgHkwzywi0hYHu0=",
-      "dev": true,
       "requires": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -12342,7 +12325,6 @@
       "version": "2.29.0",
       "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
       "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
-      "dev": true,
       "requires": {
         "tslib": "^1.8.1"
       }
@@ -12387,7 +12369,6 @@
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.13.0.tgz",
       "integrity": "sha512-jQWtvPcV+0fiLZAXFEe70v5gqjDO6pJYJz4mlTtmGJeW2KRoIU/BEfktma6Uj8Xii7UakuZjbxFewl3UYOkU/w==",
-      "dev": true,
       "requires": {
         "@types/fs-extra": "^5.0.3",
         "@types/handlebars": "^4.0.38",
@@ -12411,16 +12392,14 @@
         "@types/handlebars": {
           "version": "4.0.39",
           "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
-          "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA==",
-          "dev": true
+          "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA=="
         }
       }
     },
     "typedoc-default-themes": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz",
-      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic=",
-      "dev": true
+      "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
     },
     "typescript": {
       "version": "3.1.6",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,9 @@
     "minimatch": "^3.0.4",
     "semver": "^5.6.0",
     "spdx-license-list": "^4.0.0",
+    "tslint": "^5.11.0",
+    "typedoc": "^0.13.0",
+    "typescript": "^3.1.6",
     "uuid": "^3.2.1"
   },
   "devDependencies": {
@@ -67,10 +70,7 @@
     "prettier": "^1.14.2",
     "rimraf": "^2.6.2",
     "supervisor": "^0.12.0",
-    "ts-node": "7.0.1",
-    "tslint": "^5.11.0",
-    "typedoc": "^0.13.0",
-    "typescript": "^3.1.6"
+    "ts-node": "7.0.1"
   },
   "directories": {
     "test": "test"
@@ -91,7 +91,7 @@
     "doc": "typedoc --mode modules --excludeExternals --ignoreCompilerErrors --exclude \"**/*.d.ts\" --out doc index.ts lib",
     "git:info": "atm-git-info",
     "gql:gen": "atm-gql-gen",
-    "lint": "tslint --config tslint.json --format verbose --project . \"**/*.ts\"",
+    "lint": "tslint --config tslint.json --format verbose --project .",
     "lint:fix": "npm run lint -- --fix",
     "start": "atm-start",
     "test": "mocha --require espower-typescript/guess \"test/**/*.test.ts\"",

--- a/test/inspection/reviewComment.test.ts
+++ b/test/inspection/reviewComment.test.ts
@@ -1,0 +1,348 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    ReviewComment,
+} from "@atomist/automation-client";
+import {
+    PushImpactResponse,
+    ReviewListenerInvocation,
+} from "@atomist/sdm";
+import * as assert from "power-assert";
+import {
+    errorsExistReviewListener,
+    reviewCommentSorter,
+} from "../../lib/inspection/reviewComments";
+
+describe("reviewComments", () => {
+
+    describe("", () => {
+
+        it("should fail the goals if error comments exists", async () => {
+            const rli: ReviewListenerInvocation = {
+                review: {
+                    comments: [
+                        { severity: "error" },
+                    ],
+                },
+            } as any;
+            const r = await errorsExistReviewListener(PushImpactResponse.failGoals)(rli);
+            assert(r === PushImpactResponse.failGoals);
+        });
+
+        it("should proceed if no error comments exists", async () => {
+            const rli: ReviewListenerInvocation = {
+                review: {
+                    comments: [
+                        { severity: "warning" },
+                        { severity: "info" },
+                        { severity: "warning" },
+                    ],
+                },
+            } as any;
+            const r = await errorsExistReviewListener(PushImpactResponse.failGoals)(rli);
+            assert(r === PushImpactResponse.proceed);
+        });
+
+        it("should find an error in several comments", async () => {
+            const rli: ReviewListenerInvocation = {
+                review: {
+                    comments: [
+                        { severity: "warning" },
+                        { severity: "info" },
+                        { severity: "warning" },
+                        { severity: "error" },
+                        { severity: "info" },
+                        { severity: "warning" },
+                    ],
+                },
+            } as any;
+            const r = await errorsExistReviewListener(PushImpactResponse.failGoals)(rli);
+            assert(r === PushImpactResponse.failGoals);
+        });
+
+        it("should proceed if there are no comments", async () => {
+            const rli: ReviewListenerInvocation = {
+                review: { comments: [] },
+            } as any;
+            const r = await errorsExistReviewListener(PushImpactResponse.failGoals)(rli);
+            assert(r === PushImpactResponse.proceed);
+        });
+
+    });
+
+    describe("reviewCommentSorter", () => {
+
+        const d: ReviewComment = {
+            category: "dummy",
+            detail: "dummy detail",
+            severity: "error",
+            subcategory: "subdummy",
+            sourceLocation: {
+                path: "/a/b/c.ts",
+                offset: 0,
+            },
+        };
+
+        it("should sort nothing", () => {
+            const r: ReviewComment[] = [];
+            r.sort(reviewCommentSorter);
+            const e: ReviewComment[] = [];
+            assert.deepStrictEqual(r, e);
+        });
+
+        it("should sort by severity", () => {
+            const r: ReviewComment[] = [
+                { ...d, severity: "info" },
+                { ...d, severity: "error" },
+                { ...d, severity: "warn" },
+            ];
+            r.sort(reviewCommentSorter);
+            const e: ReviewComment[] = [
+                { ...d, severity: "error" },
+                { ...d, severity: "warn" },
+                { ...d, severity: "info" },
+            ];
+            assert.deepStrictEqual(r, e);
+        });
+
+        it("should sort by category", () => {
+            const r: ReviewComment[] = [
+                { ...d, category: "third" },
+                { ...d, category: "second" },
+                { ...d, category: "first" },
+            ];
+            r.sort(reviewCommentSorter);
+            const e: ReviewComment[] = [
+                { ...d, category: "first" },
+                { ...d, category: "second" },
+                { ...d, category: "third" },
+            ];
+            assert.deepStrictEqual(r, e);
+        });
+
+        it("should sort by subcategory", () => {
+            const r: ReviewComment[] = [
+                { ...d, subcategory: "third" },
+                { ...d, subcategory: "second" },
+                { ...d, subcategory: "first" },
+            ];
+            r.sort(reviewCommentSorter);
+            const e: ReviewComment[] = [
+                { ...d, subcategory: "first" },
+                { ...d, subcategory: "second" },
+                { ...d, subcategory: "third" },
+            ];
+            assert.deepStrictEqual(r, e);
+        });
+
+        it("should sort by path and location", () => {
+            const r: ReviewComment[] = [
+                { ...d, sourceLocation: { path: "/d/e/f.ts", offset: 7 } },
+                { ...d, sourceLocation: undefined },
+                { ...d, sourceLocation: { path: "/g/h/i.ts", offset: 0 } },
+                { ...d, sourceLocation: { path: "/d/e/f.ts", offset: 1 } },
+            ];
+            r.sort(reviewCommentSorter);
+            const e: ReviewComment[] = [
+                { ...d, sourceLocation: undefined },
+                { ...d, sourceLocation: { path: "/d/e/f.ts", offset: 1 } },
+                { ...d, sourceLocation: { path: "/d/e/f.ts", offset: 7 } },
+                { ...d, sourceLocation: { path: "/g/h/i.ts", offset: 0 } },
+            ];
+            assert.deepStrictEqual(r, e);
+        });
+
+        it("should sort comments", () => {
+            const r: ReviewComment[] = [
+                {
+                    category: "tslint",
+                    detail: "Exceeds maximum line length of 150",
+                    subcategory: "max-line-length",
+                    severity: "warn",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/test/inspection/tslint.test.ts",
+                        columnFrom1: 1,
+                        lineFrom1: 5,
+                        offset: 24,
+                    },
+                },
+                {
+                    category: "nottslint",
+                    detail: "Missing semicolon",
+                    subcategory: "semicolon",
+                    severity: "error",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/lib/inspection/tslint.ts",
+                        columnFrom1: 14,
+                        lineFrom1: 1,
+                        offset: 13,
+                    },
+                },
+                {
+                    category: "tslint",
+                    detail: "Calls to 'console.log' are not allowed.",
+                    subcategory: "no-console",
+                    severity: "warn",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/test/inspection/tslint.test.ts",
+                        columnFrom1: 1,
+                        lineFrom1: 2,
+                        offset: 14,
+                    },
+                },
+                {
+                    category: "tslint",
+                    detail: "Calls to 'console.log' are not allowed.",
+                    subcategory: "no-console",
+                    severity: "warn",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/lib/inspection/tslint.ts",
+                        columnFrom1: 1,
+                        lineFrom1: 2,
+                        offset: 14,
+                    },
+                },
+                {
+                    category: "tslint",
+                    detail: "Missing semicolon",
+                    subcategory: "semicolon",
+                    severity: "error",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/lib/inspection/tslint.ts",
+                        columnFrom1: 14,
+                        lineFrom1: 1,
+                        offset: 13,
+                    },
+                },
+                {
+                    category: "nottslint",
+                    detail: "Missing semicolon",
+                    subcategory: "semicolon",
+                    severity: "error",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/lib/inspection/reviewComment.ts",
+                        columnFrom1: 14,
+                        lineFrom1: 1,
+                        offset: 13,
+                    },
+                },
+                {
+                    category: "tslint",
+                    detail: "Exceeds maximum line length of 150",
+                    subcategory: "max-line-length",
+                    severity: "warn",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/test/inspection/tslint.test.ts",
+                        columnFrom1: 1,
+                        lineFrom1: 2,
+                        offset: 14,
+                    },
+                },
+            ];
+            r.sort(reviewCommentSorter);
+            const e: ReviewComment[] = [
+                {
+                    category: "nottslint",
+                    detail: "Missing semicolon",
+                    subcategory: "semicolon",
+                    severity: "error",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/lib/inspection/reviewComment.ts",
+                        columnFrom1: 14,
+                        lineFrom1: 1,
+                        offset: 13,
+                    },
+                },
+                {
+                    category: "nottslint",
+                    detail: "Missing semicolon",
+                    subcategory: "semicolon",
+                    severity: "error",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/lib/inspection/tslint.ts",
+                        columnFrom1: 14,
+                        lineFrom1: 1,
+                        offset: 13,
+                    },
+                },
+                {
+                    category: "tslint",
+                    detail: "Missing semicolon",
+                    subcategory: "semicolon",
+                    severity: "error",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/lib/inspection/tslint.ts",
+                        columnFrom1: 14,
+                        lineFrom1: 1,
+                        offset: 13,
+                    },
+                },
+                {
+                    category: "tslint",
+                    detail: "Exceeds maximum line length of 150",
+                    subcategory: "max-line-length",
+                    severity: "warn",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/test/inspection/tslint.test.ts",
+                        columnFrom1: 1,
+                        lineFrom1: 2,
+                        offset: 14,
+                    },
+                },
+                {
+                    category: "tslint",
+                    detail: "Exceeds maximum line length of 150",
+                    subcategory: "max-line-length",
+                    severity: "warn",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/test/inspection/tslint.test.ts",
+                        columnFrom1: 1,
+                        lineFrom1: 5,
+                        offset: 24,
+                    },
+                },
+                {
+                    category: "tslint",
+                    detail: "Calls to 'console.log' are not allowed.",
+                    subcategory: "no-console",
+                    severity: "warn",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/lib/inspection/tslint.ts",
+                        columnFrom1: 1,
+                        lineFrom1: 2,
+                        offset: 14,
+                    },
+                },
+                {
+                    category: "tslint",
+                    detail: "Calls to 'console.log' are not allowed.",
+                    subcategory: "no-console",
+                    severity: "warn",
+                    sourceLocation: {
+                        path: "/home/tom/dev/waits-sdm/test/inspection/tslint.test.ts",
+                        columnFrom1: 1,
+                        lineFrom1: 2,
+                        offset: 14,
+                    },
+                },
+            ];
+            assert.deepStrictEqual(r, e);
+        });
+
+    });
+
+});

--- a/test/inspection/tslint.test.ts
+++ b/test/inspection/tslint.test.ts
@@ -1,0 +1,168 @@
+/*
+ * Copyright © 2018 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    logger,
+} from "@atomist/automation-client";
+import {
+    PushImpactResponse,
+    ReviewListenerInvocation,
+} from "@atomist/sdm";
+import * as path from "path";
+import * as assert from "power-assert";
+import {
+    failGoalsIfErrorCommentsReviewListener,
+    mapTslintResultsToReviewComments,
+} from "../../lib/inspection/tslint";
+
+describe("tslint", () => {
+
+    describe("mapTslintResultsToReviewComments", () => {
+
+        let loggerError: any;
+        let errorMessage: string;
+        before(() => {
+            loggerError = logger.error;
+            logger.error = (message?: any, ...optionalParams: any[]) => {
+                errorMessage = message;
+                return logger;
+            };
+        });
+        after(() => {
+            logger.error = loggerError;
+        });
+
+        it("should handle an empty array", () => {
+            errorMessage = undefined;
+            const c = mapTslintResultsToReviewComments("[]", "");
+            assert(c.length === 0);
+            assert(!errorMessage);
+        });
+
+        it("should properly parse TSLint JSON output", () => {
+            errorMessage = undefined;
+            const d = "/some/path/to/something";
+            // tslint:disable-next-line:max-line-length
+            const o = `[{"endPosition":{"character":191,"line":1,"position":205},"failure":"Exceeds maximum line length of 150","name":"${d}${path.sep}test/inspection/tslint.test.ts","ruleName":"max-line-length","ruleSeverity":"WARNING","startPosition":{"character":0,"line":1,"position":14}},{"endPosition":{"character":11,"line":1,"position":25},"failure":"Calls to 'console.log' are not allowed.","name":"${d}${path.sep}lib/inspection/tslint.ts","ruleName":"no-console","ruleSeverity":"WARNING","startPosition":{"character":0,"line":1,"position":14}},{"endPosition":{"character":13,"line":0,"position":13},"failure":"Missing semicolon","fix":{"innerStart":13,"innerLength":0,"innerText":";"},"name":"${d}${path.sep}lib/inspection/tslint.ts","ruleName":"semicolon","ruleSeverity":"ERROR","startPosition":{"character":13,"line":0,"position":13}}]`;
+            const c = mapTslintResultsToReviewComments(o, d);
+            assert(c.length === 3);
+            assert(!errorMessage);
+            c.forEach(r => {
+                assert(r.category === "lint");
+                assert(r.subcategory === "tslint");
+            });
+            assert(c[0].detail === "Exceeds maximum line length of 150");
+            assert(c[0].severity === "warn");
+            assert(c[0].sourceLocation.path === "test/inspection/tslint.test.ts");
+            assert(c[0].sourceLocation.columnFrom1 === 1);
+            assert(c[0].sourceLocation.lineFrom1 === 2);
+            assert(c[0].sourceLocation.offset === 14);
+            assert(c[1].detail === "Calls to 'console.log' are not allowed.");
+            assert(c[1].severity === "warn");
+            assert(c[1].sourceLocation.path === "lib/inspection/tslint.ts");
+            assert(c[1].sourceLocation.columnFrom1 === 1);
+            assert(c[1].sourceLocation.lineFrom1 === 2);
+            assert(c[1].sourceLocation.offset === 14);
+            assert(c[2].detail === "Missing semicolon");
+            assert(c[2].severity === "error");
+            assert(c[2].sourceLocation.path === "lib/inspection/tslint.ts");
+            assert(c[2].sourceLocation.columnFrom1 === 14);
+            assert(c[2].sourceLocation.lineFrom1 === 1);
+            assert(c[2].sourceLocation.offset === 13);
+        });
+
+        it("should handle no output", () => {
+            errorMessage = undefined;
+            const c = mapTslintResultsToReviewComments("", "");
+            assert(c.length === 0);
+            assert(errorMessage);
+            assert(errorMessage.startsWith("Failed to parse TSLint output '"));
+        });
+
+        it("should handle output with just whitespace", () => {
+            errorMessage = undefined;
+            const c = mapTslintResultsToReviewComments("  \n", "");
+            assert(c.length === 0);
+            assert(errorMessage);
+            assert(errorMessage.startsWith("Failed to parse TSLint output '"));
+        });
+
+        it("should handle bad input", () => {
+            errorMessage = undefined;
+            const c = mapTslintResultsToReviewComments("]})({[", "");
+            assert(c.length === 0);
+            assert(errorMessage);
+            assert(errorMessage.startsWith("Failed to parse TSLint output '"));
+        });
+
+    });
+
+    describe("failGoalsIfErrorCommentsReviewListener", () => {
+
+        it("should fail the goals if error comments exists", async () => {
+            const rli: ReviewListenerInvocation = {
+                review: {
+                    comments: [
+                        { severity: "error" },
+                    ],
+                },
+            } as any;
+            const r = await failGoalsIfErrorCommentsReviewListener(rli);
+            assert(r === PushImpactResponse.failGoals);
+        });
+
+        it("should proceed if no error comments exists", async () => {
+            const rli: ReviewListenerInvocation = {
+                review: {
+                    comments: [
+                        { severity: "warning" },
+                        { severity: "info" },
+                        { severity: "warning" },
+                    ],
+                },
+            } as any;
+            const r = await failGoalsIfErrorCommentsReviewListener(rli);
+            assert(r === PushImpactResponse.proceed);
+        });
+
+        it("should find an error in several comments", async () => {
+            const rli: ReviewListenerInvocation = {
+                review: {
+                    comments: [
+                        { severity: "warning" },
+                        { severity: "info" },
+                        { severity: "warning" },
+                        { severity: "error" },
+                        { severity: "info" },
+                        { severity: "warning" },
+                    ],
+                },
+            } as any;
+            const r = await failGoalsIfErrorCommentsReviewListener(rli);
+            assert(r === PushImpactResponse.failGoals);
+        });
+
+        it("should proceed if there are no comments", async () => {
+            const rli: ReviewListenerInvocation = {
+                review: { comments: [] },
+            } as any;
+            const r = await failGoalsIfErrorCommentsReviewListener(rli);
+            assert(r === PushImpactResponse.proceed);
+        });
+
+    });
+
+});

--- a/test/inspection/tslint.test.ts
+++ b/test/inspection/tslint.test.ts
@@ -17,14 +17,9 @@
 import {
     logger,
 } from "@atomist/automation-client";
-import {
-    PushImpactResponse,
-    ReviewListenerInvocation,
-} from "@atomist/sdm";
 import * as path from "path";
 import * as assert from "power-assert";
 import {
-    failGoalsIfErrorCommentsReviewListener,
     mapTslintResultsToReviewComments,
 } from "../../lib/inspection/tslint";
 
@@ -61,23 +56,25 @@ describe("tslint", () => {
             assert(c.length === 3);
             assert(!errorMessage);
             c.forEach(r => {
-                assert(r.category === "lint");
-                assert(r.subcategory === "tslint");
+                assert(r.category === "tslint");
             });
             assert(c[0].detail === "Exceeds maximum line length of 150");
             assert(c[0].severity === "warn");
+            assert(c[0].subcategory === "max-line-length");
             assert(c[0].sourceLocation.path === "test/inspection/tslint.test.ts");
             assert(c[0].sourceLocation.columnFrom1 === 1);
             assert(c[0].sourceLocation.lineFrom1 === 2);
             assert(c[0].sourceLocation.offset === 14);
             assert(c[1].detail === "Calls to 'console.log' are not allowed.");
             assert(c[1].severity === "warn");
+            assert(c[1].subcategory === "no-console");
             assert(c[1].sourceLocation.path === "lib/inspection/tslint.ts");
             assert(c[1].sourceLocation.columnFrom1 === 1);
             assert(c[1].sourceLocation.lineFrom1 === 2);
             assert(c[1].sourceLocation.offset === 14);
             assert(c[2].detail === "Missing semicolon");
             assert(c[2].severity === "error");
+            assert(c[2].subcategory === "semicolon");
             assert(c[2].sourceLocation.path === "lib/inspection/tslint.ts");
             assert(c[2].sourceLocation.columnFrom1 === 14);
             assert(c[2].sourceLocation.lineFrom1 === 1);
@@ -106,61 +103,6 @@ describe("tslint", () => {
             assert(c.length === 0);
             assert(errorMessage);
             assert(errorMessage.startsWith("Failed to parse TSLint output '"));
-        });
-
-    });
-
-    describe("failGoalsIfErrorCommentsReviewListener", () => {
-
-        it("should fail the goals if error comments exists", async () => {
-            const rli: ReviewListenerInvocation = {
-                review: {
-                    comments: [
-                        { severity: "error" },
-                    ],
-                },
-            } as any;
-            const r = await failGoalsIfErrorCommentsReviewListener(rli);
-            assert(r === PushImpactResponse.failGoals);
-        });
-
-        it("should proceed if no error comments exists", async () => {
-            const rli: ReviewListenerInvocation = {
-                review: {
-                    comments: [
-                        { severity: "warning" },
-                        { severity: "info" },
-                        { severity: "warning" },
-                    ],
-                },
-            } as any;
-            const r = await failGoalsIfErrorCommentsReviewListener(rli);
-            assert(r === PushImpactResponse.proceed);
-        });
-
-        it("should find an error in several comments", async () => {
-            const rli: ReviewListenerInvocation = {
-                review: {
-                    comments: [
-                        { severity: "warning" },
-                        { severity: "info" },
-                        { severity: "warning" },
-                        { severity: "error" },
-                        { severity: "info" },
-                        { severity: "warning" },
-                    ],
-                },
-            } as any;
-            const r = await failGoalsIfErrorCommentsReviewListener(rli);
-            assert(r === PushImpactResponse.failGoals);
-        });
-
-        it("should proceed if there are no comments", async () => {
-            const rli: ReviewListenerInvocation = {
-                review: { comments: [] },
-            } as any;
-            const r = await failGoalsIfErrorCommentsReviewListener(rli);
-            assert(r === PushImpactResponse.proceed);
         });
 
     });

--- a/tslint.json
+++ b/tslint.json
@@ -2,9 +2,6 @@
   "defaultSeverity": "error",
   "extends": [],
   "jsRules": {},
-  "linterOptions": {
-    "exclude": ["node_modules/**", "**/*.d.ts"]
-  },
   "rules": {
     "adjacent-overload-signatures": true,
     "align": {
@@ -38,6 +35,7 @@
     },
     "curly": true,
     "cyclomatic-complexity": {
+      "severity": "warning",
       "options": [10]
     },
     "eofline": true,
@@ -53,12 +51,15 @@
     "jsdoc-format": true,
     "label-position": true,
     "max-classes-per-file": {
+      "severity": "warning",
       "options": [7]
     },
     "max-file-line-count": {
+      "severity": "warning",
       "options": [400]
     },
     "max-line-length": {
+      "severity": "warning",
       "options": [150]
     },
     "member-access": true,
@@ -89,12 +90,16 @@
     "no-import-side-effect": true,
     "no-inferred-empty-object-type": true,
     "no-internal-module": true,
-    "no-invalid-template-strings": true,
+    "no-invalid-template-strings": {
+      "severity": "warning"
+    },
     "no-invalid-this": true,
     "no-magic-numbers": false,
     "no-misused-new": true,
     "no-namespace": true,
-    "no-null-keyword": true,
+    "no-null-keyword": {
+      "severity": "warning"
+    },
     "no-object-literal-type-assertion": true,
     "no-parameter-properties": false,
     "no-parameter-reassignment": true,


### PR DESCRIPTION
Move execution of TSLint to a code inspection that runs after the
build rather than being part of the build.  Move the code inspections
to run after the build so the build and its publication of artifacts
occur regardless of whether the code inspection fails but overall goal
status will be failed.  Add autoCodeInspection as dependency to the
downstream release goals so they are prevented from running should
code inspection fails.  Unfortunately, the buttons for approving the
other dependency goal still appears, although pressing it does not
result in downstream steps executing, as one would wish.  The TSLint
autofix still runs prior to the build.  Also remove TypeDoc generation
from the build.

Move typescript and tslint from devDependencies to dependencies since
we use this project's tslint version and configuration rather than
each projects'.

Use sdm-pack-issue review listener on TSLint auto code fix that
creates and assigns an issue if there are violations.  Provide no more
than 20 comments on review so we do not try to create a GitHub issue
with a body that is too large.  If there are more than 20, truncate to
20 and add an item indicating only the first 20 were included.

Create and use another listener that fails the auto code inspection
goal if there are comments.

Update TSLint configuration, making stylistic and newer rule
violations warnings rather than errors to ease transition to the new
rules for projects that are not up to date.