### PR TITLE
Sync up kube specs and Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,14 +3,8 @@ FROM ubuntu:18.04
 LABEL maintainer="Atomist <docker@atomist.com>"
 
 RUN apt-get update && apt-get install -y \
-        curl \
+        dumb-init \
     && rm -rf /var/lib/apt/lists/*
-
-ENV DUMB_INIT_VERSION=1.2.2
-
-RUN curl -s -L -O https://github.com/Yelp/dumb-init/releases/download/v$DUMB_INIT_VERSION/dumb-init_${DUMB_INIT_VERSION}_amd64.deb \
-    && dpkg -i dumb-init_${DUMB_INIT_VERSION}_amd64.deb \
-    && rm -f dumb-init_${DUMB_INIT_VERSION}_amd64.deb
 
 RUN mkdir -p /opt/app
 
@@ -22,7 +16,6 @@ ENV BLUEBIRD_WARNINGS 0
 ENV NODE_ENV production
 ENV NPM_CONFIG_LOGLEVEL warn
 ENV SUPPRESS_NO_CONFIG_WARNING true
-ENV NODE_OPTIONS --no-deprecation
 
 ENTRYPOINT ["dumb-init", "node", "--trace-warnings", "--expose_gc", "--optimize_for_size", "--always_compact", "--max_old_space_size=384"]
 
@@ -30,10 +23,8 @@ CMD ["/opt/app/node_modules/.bin/atm-start"]
 
 RUN apt-get update && apt-get install -y \
         build-essential \
-        docker.io \
+        curl \
         git \
-        unzip \
-        openjdk-8-jdk \
     && rm -rf /var/lib/apt/lists/*
 
 RUN git config --global user.email "bot@atomist.com" \
@@ -43,16 +34,24 @@ RUN curl -sL https://deb.nodesource.com/setup_11.x | bash - \
     && apt-get install -y nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl -sL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.8/bin/linux/amd64/kubectl \
-    && chmod +x /usr/local/bin/kubectl
+RUN apt-get update && apt-get install -y \
+        docker.io \
+        openjdk-8-jdk-headless \
+        unzip \
+    && rm -rf /var/lib/apt/lists/*
 
 ENV LEIN_ROOT true
 RUN curl -sL -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein \
     && chmod +x /usr/local/bin/lein
 
+RUN curl -sL -o /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.10.8/bin/linux/amd64/kubectl \
+    && chmod +x /usr/local/bin/kubectl
+
 COPY package.json package-lock.json ./
 
-RUN NODE_ENV=development npm ci \
+RUN npm ci \
     && npm cache clean --force
 
 COPY . .
+
+ENV NODE_OPTIONS --no-deprecation

--- a/assets/kube/deployment-no-rbac.yaml
+++ b/assets/kube/deployment-no-rbac.yaml
@@ -1,127 +1,101 @@
----
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
-  name: sample-sdm
+  name: atomist-sdm
   namespace: sdm
   labels:
-    app: sample-sdm
+    app: atomist-sdm
     owner: atomist
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: sample-sdm
+      app: atomist-sdm
       owner: atomist
   template:
     metadata:
       labels:
-        app: sample-sdm
+        app: atomist-sdm
         owner: atomist
         version: "0"
       annotations:
         atomist.com/k8vent: '{"webhooks":["https://webhook.atomist.com/atomist/kube/teams/T29E48P34"]}'
     spec:
       containers:
-      - name: sample-sdm
-        image: sforzando-dockerv2-local.jfrog.io/sample-sdm:0.0.15-fork-work.20180426220432
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: ATOMIST_DEPLOYMENT_NAME
-          value: sample-sdm
-        - name: ATOMIST_DEPLOYMENT_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: APP_NAME
-          value: sample-sdm
-        - name: NODE_ENV
-          value: production
-        - name: FORCE_COLOR
-          value: '1'
-        - name: ATOMIST_GOAL_LAUNCHER
-          value: kubernetes
-        - name: GITHUB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: atomist
-              key: token
-        - name: ATOMIST_CONFIG
-          valueFrom:
-            secretKeyRef:
-              name: atm-sdm
-              key: config
-        - name: ATOMIST_CONFIG_PATH
-          value: "/opt/atm/atomist-config.json"
-        - name: ATOMIST_DOCKER_REGISTRY
-          valueFrom:
-            secretKeyRef:
-              name: docker
-              key: registry
-        - name: ATOMIST_DOCKER_USER
-          valueFrom:
-            secretKeyRef:
-              name: docker
-              key: user
-        - name: ATOMIST_DOCKER_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: docker
-              key: password
-        - name: ATOMIST_NPM
-          valueFrom:
-            secretKeyRef:
-              name: npm
-              key: config
-        ports:
-        - name: http
-          containerPort: 2866
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 20
-          timeoutSeconds: 3
-          periodSeconds: 20
-          successThreshold: 1
-          failureThreshold: 3
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 20
-          timeoutSeconds: 3
-          periodSeconds: 20
-          successThreshold: 1
-          failureThreshold: 3
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 3000Mi
-          requests:
-            cpu: 500m
-            memory: 1000Mi
-        volumeMounts:
-        - name: docker-sock
-          mountPath: "/var/run/docker.sock"
-        - name: automation
-          mountPath: "/opt/atm"
+        - name: atomist-sdm
+          image: atomist/atomist-sdm:1.0.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ATOMIST_DEPLOYMENT_NAME
+              value: atomist-sdm
+            - name: ATOMIST_DEPLOYMENT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: FORCE_COLOR
+              value: "1"
+            - name: ATOMIST_GOAL_LAUNCHER
+              value: kubernetes
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: atomist
+                  key: token
+            - name: ATOMIST_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: atm-sdm
+                  key: config
+            - name: ATOMIST_CONFIG_PATH
+              value: "/opt/atm/atomist-config.json"
+          ports:
+            - name: http
+              containerPort: 2866
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: "/health"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 3
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 3
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 3000Mi
+            requests:
+              cpu: 500m
+              memory: 1000Mi
+          volumeMounts:
+            - name: docker-sock
+              mountPath: "/var/run/docker.sock"
+            - name: automation
+              mountPath: "/opt/atm"
+              readOnly: true
       volumes:
-      - name: docker-sock
-        hostPath:
-          path: "/var/run/docker.sock"
-      - name: automation
-        secret:
-          secretName: automation
+        - name: docker-sock
+          hostPath:
+            path: "/var/run/docker.sock"
+        - name: automation
+          secret:
+            secretName: automation
       restartPolicy: Always
       terminationGracePeriodSeconds: 180
       dnsPolicy: ClusterFirst
-      imagePullSecrets:
-      - name: atomistjfrog
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/assets/kube/deployment-rbac.yaml
+++ b/assets/kube/deployment-rbac.yaml
@@ -1,23 +1,22 @@
----
 kind: Deployment
 apiVersion: extensions/v1beta1
 metadata:
-  name: automation-client-sdm
+  name: atomist-sdm
   namespace: sdm
   labels:
-    app: automation-client-sdm
+    app: atomist-sdm
     owner: atomist
 spec:
   replicas: 1
   revisionHistoryLimit: 3
   selector:
     matchLabels:
-      app: automation-client-sdm
+      app: atomist-sdm
       owner: atomist
   template:
     metadata:
       labels:
-        app: automation-client-sdm
+        app: atomist-sdm
         owner: atomist
         version: "0"
       annotations:
@@ -25,103 +24,79 @@ spec:
     spec:
       serviceAccountName: sdm-serviceaccount
       containers:
-      - name: automation-client-sdm
-        image: sforzando-dockerv2-local.jfrog.io/automation-client-sdm:0.0.1-20180502125121
-        imagePullPolicy: IfNotPresent
-        env:
-        - name: ATOMIST_DEPLOYMENT_NAME
-          value: automation-client-sdm
-        - name: ATOMIST_DEPLOYMENT_NAMESPACE
-          valueFrom:
-            fieldRef:
-              fieldPath: metadata.namespace
-        - name: NODE_ENV
-          value: production
-        - name: FORCE_COLOR
-          value: '1'
-        - name: ATOMIST_GOAL_LAUNCHER
-          value: kubernetes
-        - name: GITHUB_TOKEN
-          valueFrom:
-            secretKeyRef:
-              name: atomist
-              key: token
-        - name: ATOMIST_CONFIG
-          valueFrom:
-            secretKeyRef:
-              name: atm-sdm
-              key: config
-        - name: ATOMIST_CONFIG_PATH
-          value: "/opt/atm/atomist-config.json"
-        - name: ATOMIST_DOCKER_REGISTRY
-          valueFrom:
-            secretKeyRef:
-              name: docker
-              key: registry
-        - name: ATOMIST_DOCKER_USER
-          valueFrom:
-            secretKeyRef:
-              name: docker
-              key: user
-        - name: ATOMIST_DOCKER_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: docker
-              key: password
-        - name: ATOMIST_NPM
-          valueFrom:
-            secretKeyRef:
-              name: npm
-              key: config
-        ports:
-        - name: http
-          containerPort: 2866
-          protocol: TCP
-        readinessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 20
-          timeoutSeconds: 3
-          periodSeconds: 20
-          successThreshold: 1
-          failureThreshold: 3
-        livenessProbe:
-          httpGet:
-            path: "/health"
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 20
-          timeoutSeconds: 3
-          periodSeconds: 20
-          successThreshold: 1
-          failureThreshold: 3
-        resources:
-          limits:
-            cpu: 2000m
-            memory: 3000Mi
-          requests:
-            cpu: 500m
-            memory: 1000Mi
-        volumeMounts:
-        - name: docker-sock
-          mountPath: "/var/run/docker.sock"
-        - name: automation
-          mountPath: "/opt/atm"
-          readOnly: true
+        - name: atomist-sdm
+          image: atomist/atomist-sdm:1.0.1
+          imagePullPolicy: IfNotPresent
+          env:
+            - name: ATOMIST_DEPLOYMENT_NAME
+              value: atomist-sdm
+            - name: ATOMIST_DEPLOYMENT_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: FORCE_COLOR
+              value: "1"
+            - name: ATOMIST_GOAL_LAUNCHER
+              value: kubernetes
+            - name: GITHUB_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: atomist
+                  key: token
+            - name: ATOMIST_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: atm-sdm
+                  key: config
+            - name: ATOMIST_CONFIG_PATH
+              value: "/opt/atm/atomist-config.json"
+          ports:
+            - name: http
+              containerPort: 2866
+              protocol: TCP
+          readinessProbe:
+            httpGet:
+              path: "/health"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 3
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: "/health"
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: 20
+            timeoutSeconds: 3
+            periodSeconds: 20
+            successThreshold: 1
+            failureThreshold: 3
+          resources:
+            limits:
+              cpu: 2000m
+              memory: 3000Mi
+            requests:
+              cpu: 500m
+              memory: 1000Mi
+          volumeMounts:
+            - name: docker-sock
+              mountPath: "/var/run/docker.sock"
+            - name: automation
+              mountPath: "/opt/atm"
+              readOnly: true
       volumes:
-      - name: docker-sock
-        hostPath:
-          path: "/var/run/docker.sock"
-      - name: automation
-        secret:
-          secretName: automation
+        - name: docker-sock
+          hostPath:
+            path: "/var/run/docker.sock"
+        - name: automation
+          secret:
+            secretName: automation
       restartPolicy: Always
       terminationGracePeriodSeconds: 180
       dnsPolicy: ClusterFirst
-      imagePullSecrets:
-      - name: atomistjfrog
   strategy:
     type: RollingUpdate
     rollingUpdate:

--- a/assets/kube/rbac.yaml
+++ b/assets/kube/rbac.yaml
@@ -10,6 +10,9 @@ metadata:
   name: sdm-role
   namespace: sdm
 rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["extensions", "apps"]
     resources: ["deployments"]
     verbs: ["get", "list", "watch"]

--- a/lib/machine/k8Support.ts
+++ b/lib/machine/k8Support.ts
@@ -32,16 +32,23 @@ export function kubernetesDeploymentData(sdm: SoftwareDeliveryMachine): (g: SdmG
             id: context.id,
             readOnly: true,
         }, async p => {
+            const name = goal.repo.name;
+            const environment = sdm.configuration.environment.split("_")[0];
             const ns = namespaceFromGoal(goal);
             const ingress = ingressFromGoal(goal.repo.name, ns);
             const port = (await IsMaven.predicate(p)) ? 8080 : 2866;
+            let replicas = 1;
+            if (ns === "production") {
+                replicas = 3;
+            } else if (ns === "sdm" && name === "atomist-sdm") {
+                replicas = 3;
+            }
             return {
-                name: goal.repo.name,
-                environment: sdm.configuration.environment.split("_")[0],
+                name,
+                environment,
                 port,
                 ns,
-                imagePullSecret: "atomistjfrog",
-                replicas: ns === "production" ? 3 : 1,
+                replicas,
                 ...ingress,
             };
         });

--- a/test/machine/k8Support.test.ts
+++ b/test/machine/k8Support.test.ts
@@ -14,10 +14,283 @@
  * limitations under the License.
  */
 
+import {
+    GitProject,
+    InMemoryProject,
+} from "@atomist/automation-client";
+import {
+    RepoContext,
+    SdmGoalEvent,
+    SoftwareDeliveryMachine,
+} from "@atomist/sdm";
+import { KubernetesApplicationOptions } from "@atomist/sdm-pack-k8";
 import * as assert from "power-assert";
-import { ingressFromGoal } from "../../lib/machine/k8Support";
+import {
+    ingressFromGoal,
+    kubernetesDeploymentData,
+} from "../../lib/machine/k8Support";
 
 describe("k8Support", () => {
+
+    describe("kubernetesDeploymentData", () => {
+
+        function sdmGen(gp: GitProject): SoftwareDeliveryMachine {
+            return {
+                projectLoader: {
+                    doWithProject: async (params: any, action: (p: GitProject) => Promise<KubernetesApplicationOptions>) => action(gp),
+                },
+            } as any;
+        }
+        const context: RepoContext = {
+            credentials: "creds",
+            id: {},
+        } as any;
+
+        it("should provide function that generates Kubernetes deployment data", async () => {
+            const p: GitProject = InMemoryProject.of() as any;
+            const environment = "testing";
+            const sdm: SoftwareDeliveryMachine = {
+                configuration: {
+                    environment,
+                    sdm: sdmGen(p),
+                },
+            } as any;
+            const goal: SdmGoalEvent = {
+                environment,
+                repo: {
+                    name: "rocknroll",
+                },
+            } as any;
+            const d = await kubernetesDeploymentData(sdm)(goal, context);
+            assert(d);
+            const e = {
+                name: "rocknroll",
+                environment,
+                port: 2866,
+                ns: "default",
+                replicas: 1,
+            };
+            assert.deepStrictEqual(d, e);
+        });
+
+        it("should set port for Maven project", async () => {
+            const p: GitProject = InMemoryProject.of({ path: "pom.xml", content: "" }) as any;
+            const environment = "testing";
+            const sdm: SoftwareDeliveryMachine = {
+                configuration: {
+                    environment,
+                    sdm: sdmGen(p),
+                },
+            } as any;
+            const goal: SdmGoalEvent = {
+                environment,
+                repo: {
+                    name: "rocknroll",
+                },
+            } as any;
+            const d = await kubernetesDeploymentData(sdm)(goal, context);
+            assert(d);
+            const e = {
+                name: "rocknroll",
+                environment,
+                port: 8080,
+                ns: "default",
+                replicas: 1,
+            };
+            assert.deepStrictEqual(d, e);
+        });
+
+        it("should detect staging environment", async () => {
+            const p: GitProject = InMemoryProject.of() as any;
+            const sdm: SoftwareDeliveryMachine = {
+                configuration: {
+                    environment: "myk8_testing",
+                    sdm: sdmGen(p),
+                },
+            } as any;
+            const goal: SdmGoalEvent = {
+                environment: "1-staging",
+                repo: {
+                    name: "rocknroll",
+                },
+            } as any;
+            const d = await kubernetesDeploymentData(sdm)(goal, context);
+            assert(d);
+            const e = {
+                name: "rocknroll",
+                environment: "myk8",
+                port: 2866,
+                ns: "testing",
+                replicas: 1,
+            };
+            assert.deepStrictEqual(d, e);
+        });
+
+        it("should detect production environment", async () => {
+            const p: GitProject = InMemoryProject.of() as any;
+            const sdm: SoftwareDeliveryMachine = {
+                configuration: {
+                    environment: "myk8_prod",
+                    sdm: sdmGen(p),
+                },
+            } as any;
+            const goal: SdmGoalEvent = {
+                environment: "2-prod",
+                repo: {
+                    name: "rocknroll",
+                },
+            } as any;
+            const d = await kubernetesDeploymentData(sdm)(goal, context);
+            assert(d);
+            const e = {
+                name: "rocknroll",
+                environment: "myk8",
+                port: 2866,
+                ns: "production",
+                replicas: 3,
+            };
+            assert.deepStrictEqual(d, e);
+        });
+
+        it("should detect atomist-sdm", async () => {
+            const p: GitProject = InMemoryProject.of() as any;
+            const sdm: SoftwareDeliveryMachine = {
+                configuration: {
+                    environment: "myk8_prod",
+                    sdm: sdmGen(p),
+                },
+            } as any;
+            const goal: SdmGoalEvent = {
+                environment: "2-prod",
+                repo: {
+                    name: "atomist-sdm",
+                },
+            } as any;
+            const d = await kubernetesDeploymentData(sdm)(goal, context);
+            assert(d);
+            const e = {
+                name: "atomist-sdm",
+                environment: "myk8",
+                port: 2866,
+                ns: "sdm",
+                replicas: 3,
+            };
+            assert.deepStrictEqual(d, e);
+        });
+
+        it("should detect atomist-internal-sdm", async () => {
+            const p: GitProject = InMemoryProject.of() as any;
+            const sdm: SoftwareDeliveryMachine = {
+                configuration: {
+                    environment: "myk8_prod",
+                    sdm: sdmGen(p),
+                },
+            } as any;
+            const goal: SdmGoalEvent = {
+                environment: "1-staging",
+                repo: {
+                    name: "atomist-internal-sdm",
+                },
+            } as any;
+            const d = await kubernetesDeploymentData(sdm)(goal, context);
+            assert(d);
+            const e = {
+                name: "atomist-internal-sdm",
+                environment: "myk8",
+                port: 2866,
+                ns: "sdm-testing",
+                replicas: 1,
+            };
+            assert.deepStrictEqual(d, e);
+        });
+
+        it("should provide an ingress", async () => {
+            const p: GitProject = InMemoryProject.of() as any;
+            const sdm: SoftwareDeliveryMachine = {
+                configuration: {
+                    environment: "myk8_prod",
+                    sdm: sdmGen(p),
+                },
+            } as any;
+            const goal: SdmGoalEvent = {
+                environment: "1-staging",
+                repo: {
+                    name: "card-automation",
+                },
+            } as any;
+            const d = await kubernetesDeploymentData(sdm)(goal, context);
+            assert(d);
+            const e = {
+                name: "card-automation",
+                environment: "myk8",
+                port: 2866,
+                ns: "testing",
+                replicas: 1,
+                host: "pusher.atomist.services",
+                path: "/",
+                tlsSecret: "star-atomist-services",
+            };
+            assert.deepStrictEqual(d, e);
+        });
+
+        it("should provide a production ingress", async () => {
+            const p: GitProject = InMemoryProject.of() as any;
+            const sdm: SoftwareDeliveryMachine = {
+                configuration: {
+                    environment: "myk8_prod",
+                    sdm: sdmGen(p),
+                },
+            } as any;
+            const goal: SdmGoalEvent = {
+                environment: "2-prod",
+                repo: {
+                    name: "intercom-automation",
+                },
+            } as any;
+            const d = await kubernetesDeploymentData(sdm)(goal, context);
+            assert(d);
+            const e = {
+                name: "intercom-automation",
+                environment: "myk8",
+                port: 2866,
+                ns: "production",
+                replicas: 3,
+                host: "intercom.atomist.com",
+                path: "/",
+                tlsSecret: "star-atomist-com",
+            };
+            assert.deepStrictEqual(d, e);
+        });
+
+        it("should not use TLS for badge", async () => {
+            const p: GitProject = InMemoryProject.of() as any;
+            const sdm: SoftwareDeliveryMachine = {
+                configuration: {
+                    environment: "myk8_prod",
+                    sdm: sdmGen(p),
+                },
+            } as any;
+            const goal: SdmGoalEvent = {
+                environment: "2-prod",
+                repo: {
+                    name: "sdm-automation",
+                },
+            } as any;
+            const d = await kubernetesDeploymentData(sdm)(goal, context);
+            assert(d);
+            const e = {
+                name: "sdm-automation",
+                environment: "myk8",
+                port: 2866,
+                ns: "production",
+                replicas: 3,
+                host: "badge.atomist.com",
+                path: "/",
+            };
+            assert.deepStrictEqual(d, e);
+        });
+
+    });
 
     describe("ingressFromGoal", () => {
 


### PR DESCRIPTION
Update Kubernetes specs to make them consistent with each other and
the deployed atomist-sdm.  Update the Dockerfile to optimize shared
layers, used the dumb-init package in Ubuntu, and move customization
to the bottom.

Update Kubernetes data function to account for three replicas for
atomist-sdm and add tests.