### PR TITLE
Add simple Docker build

### DIFF
--- a/lib/machine/dockerSupport.ts
+++ b/lib/machine/dockerSupport.ts
@@ -17,10 +17,12 @@
 import {
     allSatisfied,
     anySatisfied,
+    formatDate,
     LogSuppressor,
     not,
     SoftwareDeliveryMachine,
 } from "@atomist/sdm";
+import { ProjectIdentifier } from "@atomist/sdm-core";
 import {
     DockerOptions,
     HasDockerfile,
@@ -31,8 +33,16 @@ import {
     isNamed,
     isOrgNamed,
 } from "../support/identityPushTests";
-import { releaseDocker } from "./goals";
-import { executeReleaseDocker } from "./release";
+import {
+    dockerBuild,
+    releaseDocker,
+    releaseVersion,
+    version,
+} from "./goals";
+import {
+    executeReleaseDocker,
+    executeReleaseVersion,
+} from "./release";
 
 /**
  * Add Docker implementations of goals to SDM.
@@ -42,20 +52,73 @@ import { executeReleaseDocker } from "./release";
  */
 export function addDockerSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMachine {
 
+    const simpleDockerPushTest = allSatisfied(HasDockerfile, not(IsNode), not(IsMaven), isOrgNamed("atomist"));
+
+    version.with({
+        name: "file-versioner",
+        versioner: async (sdmGoal, p, log) => {
+            const baseVersion: string = (await fileProjectIdentifier(p)).version;
+            log.write(`Using base version '${baseVersion}'`);
+            const branch = sdmGoal.branch;
+            const branchSuffix = (branch === sdmGoal.push.repo.defaultBranch) ? "" :
+                "branch-" + branch.replace(/[_/]/g, "-") + ".";
+            log.write(`Commit is on branch '${branch}', using '${branchSuffix}'`);
+            const ts = formatDate();
+            log.write(`Current timestamp is '${ts}'`);
+            const prereleaseVersion = `${baseVersion}-${branchSuffix}${ts}`;
+            log.write(`Calculated pre-release version '${prereleaseVersion}'`);
+            return prereleaseVersion;
+        },
+        logInterpreter: LogSuppressor,
+        pushTest: simpleDockerPushTest,
+    });
+
+    dockerBuild.with({
+        name: "simple-docker-build",
+        options: {
+            ...sdm.configuration.sdm.docker.hub as DockerOptions,
+            push: true,
+            builder: "docker",
+        },
+        logInterpreter: LogSuppressor,
+        pushTest: simpleDockerPushTest,
+    });
+
     releaseDocker
         .with({
             name: "docker-release-global-sdm",
-            goalExecutor: executeReleaseDocker(
-                sdm.configuration.sdm.docker.t095sffbk as DockerOptions),
+            goalExecutor: executeReleaseDocker(sdm.configuration.sdm.docker.t095sffbk as DockerOptions),
             pushTest: allSatisfied(IsNode, HasDockerfile, allSatisfied(isOrgNamed("atomisthq"), isNamed("global-sdm"))),
             logInterpreter: LogSuppressor,
-        }).with({
-        name: "docker-release",
-        goalExecutor: executeReleaseDocker(
-            sdm.configuration.sdm.docker.hub as DockerOptions),
-        pushTest: allSatisfied(anySatisfied(IsNode, IsMaven), HasDockerfile, not(allSatisfied(isOrgNamed("atomisthq"), isNamed("global-sdm")))),
+        })
+        .with({
+            name: "docker-release",
+            goalExecutor: executeReleaseDocker(sdm.configuration.sdm.docker.hub as DockerOptions),
+            pushTest: allSatisfied(anySatisfied(IsNode, IsMaven), HasDockerfile, not(allSatisfied(isOrgNamed("atomisthq"), isNamed("global-sdm")))),
+            logInterpreter: LogSuppressor,
+        })
+        .with({
+            name: "simple-docker-release",
+            goalExecutor: executeReleaseDocker(sdm.configuration.sdm.docker.hub as DockerOptions),
+            pushTest: simpleDockerPushTest,
+            logInterpreter: LogSuppressor,
+        });
+
+    releaseVersion.with({
+        name: "file-release-version",
+        goalExecutor: executeReleaseVersion(fileProjectIdentifier,
+            // tslint:disable-next-line:no-invalid-template-strings
+            { command: "bash", args: ["-c", 'if [[ -f VERSION ]];then v=$(<VERSION);p=${v##*.};echo "${v%.*}.$((++p))" >VERSION;fi'] }),
         logInterpreter: LogSuppressor,
+        pushTest: simpleDockerPushTest,
     });
 
     return sdm;
 }
+
+const fileProjectIdentifier: ProjectIdentifier = async p => {
+    const versionFile = await p.getFile("VERSION");
+    const versionContents = (versionFile) ? await versionFile.getContent() : "0.0.0";
+    const v = versionContents.trim();
+    return { name: p.name, version: v };
+};

--- a/lib/machine/goals.ts
+++ b/lib/machine/goals.ts
@@ -41,6 +41,7 @@ export const version = new Version();
 export const autofix = new Autofix();
 export const build = new Build();
 export const tag = new Tag();
+export const tagWithApproval = new Tag({ approval: true });
 export const dockerBuild = new DockerBuild();
 export const fingerprint = new Fingerprint();
 
@@ -195,6 +196,14 @@ export const DockerReleaseGoals = goals("Docker Build with Release")
     .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(publishWithApproval, autoCodeInspection)
     .plan(releaseChangelog).after(releaseVersion)
     .plan(releaseTag, releaseHomebrew).after(releaseNpm, releaseDocker);
+
+export const SimpleDockerReleaseGoals = goals("Simple Docker Build with Release")
+    .plan(version)
+    .plan(dockerBuild).after(version)
+    .plan(tagWithApproval).after(dockerBuild)
+    .plan(releaseDocker, releaseVersion).after(tagWithApproval)
+    .plan(releaseChangelog).after(releaseVersion)
+    .plan(releaseTag).after(releaseDocker);
 
 // Docker build and testing and production kubernetes deploy
 export const KubernetesDeployGoals = goals("Deploy")

--- a/lib/machine/machine.ts
+++ b/lib/machine/machine.ts
@@ -93,6 +93,7 @@ import {
     MavenBuildGoals,
     MavenDockerReleaseGoals,
     MultiKubernetesDeployGoals,
+    SimpleDockerReleaseGoals,
     SimplifiedKubernetesDeployGoals,
 } from "./goals";
 import { addHomebrewSupport } from "./homebrewSupport";
@@ -186,6 +187,10 @@ export function machine(configuration: SoftwareDeliveryMachineConfiguration): So
         whenPushSatisfies(anySatisfied(IsNode), HasDockerfile)
             .itMeans("Docker Build")
             .setGoals(DockerGoals),
+
+        whenPushSatisfies(HasDockerfile, isOrgNamed("atomist"))
+            .itMeans("Simple Docker Release Build")
+            .setGoals(SimpleDockerReleaseGoals),
 
         whenPushSatisfies(IsNode, not(HasDockerfile), ToDefaultBranch)
             .itMeans("Release Build")

--- a/package-lock.json
+++ b/package-lock.json
@@ -246,24 +246,24 @@
       "integrity": "sha512-n0JV8GmB3KkOgyqeMteVJK+gfQU3YLGvCX0bjbpCstqbxV1ogFYiTTgbA/J7eDD25W2jpKOc21piFoeLsGJo2Q=="
     },
     "@atomist/sdm": {
-      "version": "1.3.0-master.20190312121102",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-1.3.0-master.20190312121102.tgz",
-      "integrity": "sha512-+BuNIq3nls10ybGfDpxGlSX+lYW/c9AbIRbvto+n4zrIbiZbs/S2iDBwYsgb6j0mJneK+HPPuh2VTt8rGGmp9g==",
+      "version": "1.3.1-master.20190329134249",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-1.3.1-master.20190329134249.tgz",
+      "integrity": "sha512-5eqYYcdzgsfr+06Ow6FGI8IYkoaZs7tnh9dnfhjC+qkN14BXthI4xq7ZYzPure3M0yVeqoFwVmDMGVlUMo/+0A==",
       "requires": {
-        "@types/cron": "^1.6.0",
+        "@types/cron": "^1.6.1",
         "@types/dateformat": "^3.0.0",
         "@types/find-up": "^2.1.1",
         "@types/fs-extra": "^5.0.5",
         "@types/json-stringify-safe": "^5.0.0",
         "@types/jssha": "^2.0.0",
-        "@types/lodash": "^4.14.121",
+        "@types/lodash": "^4.14.123",
         "@types/minimatch": "^3.0.3",
-        "@types/node": "^11.9.4",
+        "@types/node": "^11.11.3",
         "@types/sprintf-js": "^1.1.2",
         "@types/stack-trace": "^0.0.29",
         "axios": "^0.19.0-beta.1",
         "base64-js": "^1.3.0",
-        "cron": "^1.6.0",
+        "cron": "^1.7.0",
         "dateformat": "^3.0.3",
         "find-up": "^3.0.0",
         "fs-extra": "^7.0.1",
@@ -277,9 +277,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "11.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-          "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
+          "version": "11.12.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.12.1.tgz",
+          "integrity": "sha512-sKDlqv6COJrR7ar0+GqqhrXQDzQlMcqMnF2iEU6m9hLo8kxozoAGUazwPyELHlRVmjsbvlnGXjnzyptSXVmceA=="
         }
       }
     },
@@ -1490,10 +1490,11 @@
       }
     },
     "@types/cron": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-1.6.1.tgz",
-      "integrity": "sha512-abeTtw2np7TTWM6Oe6gCayxv7y+vooT8qXS84PS1NLi++P51IACO1Cwsu3KhjRyL0a48kfv8547wekTrMK8dTA==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@types/cron/-/cron-1.7.0.tgz",
+      "integrity": "sha512-LRu/XiiOExELholyEwEuSTPAEiO+sVR1nXmWEjezneGgYpDyMNVIsjiaHYBoCEUJo4F1hCOlAzQAh80iEUVbKw==",
       "requires": {
+        "@types/node": "*",
         "moment": ">=2.14.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@atomist/automation-client-ext-logzio": "1.0.2-master.20181213233859",
     "@atomist/automation-client-ext-raven": "1.0.2-master.20181213200324",
     "@atomist/microgrammar": "1.0.1-master.20181109093737",
-    "@atomist/sdm": "1.3.0-master.20190312121102",
+    "@atomist/sdm": "1.3.1-master.20190329134249",
     "@atomist/sdm-core": "1.3.0-master.20190301203019",
     "@atomist/sdm-pack-analysis": "0.1.0-master.20190303112340",
     "@atomist/sdm-pack-build": "1.0.4-master.20190313094248",


### PR DESCRIPTION
Add ability to build simple Docker images, i.e., those that have no
prerequisite steps to perform.  These goals can build and push
atomist/sdm-base.