### PR TITLE
Add support for building static web sites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,14 @@ FROM atomist/sdm-base:0.2.0
 
 RUN apt-get update && apt-get install -y \
         openjdk-8-jdk-headless maven \
+        bundler \
     && rm -rf /var/lib/apt/lists/*
 
 ENV LEIN_ROOT true
 RUN curl -sL -o /usr/local/bin/lein https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein \
     && chmod +x /usr/local/bin/lein
+
+RUN curl https://htmltest.wjdp.uk | sudo bash -s -- -b /usr/local/bin
 
 COPY package.json package-lock.json ./
 

--- a/lib/machine/version.ts
+++ b/lib/machine/version.ts
@@ -1,0 +1,83 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { GitProject } from "@atomist/automation-client";
+import {
+    formatDate,
+    LogSuppressor,
+    ProgressLog,
+    PushTest,
+    SdmGoalEvent,
+    SoftwareDeliveryMachine,
+} from "@atomist/sdm";
+import {
+    ProjectIdentifier,
+    ProjectVersionerRegistration,
+} from "@atomist/sdm-core";
+import { version } from "./goals";
+
+/**
+ * Version projects based on the value in the file `VERSION`.
+ */
+export async function fileVersioner(sdmGoal: SdmGoalEvent, p: GitProject, log: ProgressLog): Promise<string> {
+    const baseVersion: string = (await fileProjectIdentifier(p)).version;
+    log.write(`Using base version '${baseVersion}'`);
+    const branch = sdmGoal.branch;
+    const branchSuffix = (branch === sdmGoal.push.repo.defaultBranch) ? "" :
+        "branch-" + branch.replace(/[_/]/g, "-") + ".";
+    log.write(`Commit is on branch '${branch}', using '${branchSuffix}'`);
+    const ts = formatDate();
+    log.write(`Current timestamp is '${ts}'`);
+    const prereleaseVersion = `${baseVersion}-${branchSuffix}${ts}`;
+    log.write(`Calculated pre-release version '${prereleaseVersion}'`);
+    return prereleaseVersion;
+}
+
+export const HasFileVersion: PushTest = {
+    name: "HasFileVersion",
+    mapping: inv => inv.project.hasFile("VERSION"),
+};
+
+export const FileVersionerRegistration: ProjectVersionerRegistration = {
+    name: "file-versioner",
+    versioner: fileVersioner,
+    logInterpreter: LogSuppressor,
+    pushTest: HasFileVersion,
+};
+
+/**
+ * Command for incrementing the patch value in `VERSION`.
+ */
+export const fileReleaseVersionCommand = {
+    command: "bash",
+    // tslint:disable-next-line:no-invalid-template-strings
+    args: ["-c", 'if [[ -f VERSION ]];then v=$(<VERSION);p=${v##*.};echo "${v%.*}.$((++p))" >VERSION;fi'],
+};
+
+/**
+ * Project identifier for projects storing the version in `VERSION`.
+ */
+export const fileProjectIdentifier: ProjectIdentifier = async p => {
+    const versionFile = await p.getFile("VERSION");
+    const versionContents = (versionFile) ? await versionFile.getContent() : "0.0.0";
+    const v = versionContents.trim();
+    return { name: p.name, version: v };
+};
+
+export function addFileVersionerSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMachine {
+    version.with(FileVersionerRegistration);
+    return sdm;
+}

--- a/lib/machine/webSupport.ts
+++ b/lib/machine/webSupport.ts
@@ -1,0 +1,233 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitProject,
+    isLocalProject,
+    logger,
+    NoParameters,
+    Project,
+    ProjectReview,
+    RemoteRepoRef,
+    ReviewComment,
+    Severity,
+    SourceLocation,
+} from "@atomist/automation-client";
+import {
+    CodeInspection,
+    CodeInspectionRegistration,
+    execPromise,
+    ExecuteGoalResult,
+    GoalInvocation,
+    GoalProjectListenerEvent,
+    GoalProjectListenerRegistration,
+    LogSuppressor,
+    PushTest,
+    spawnLog,
+    SpawnLogCommand,
+    SpawnLogOptions,
+} from "@atomist/sdm";
+import {
+    Builder,
+    spawnBuilder,
+} from "@atomist/sdm-pack-build";
+import * as fs from "fs-extra";
+import * as path from "path";
+
+export const IsJekyllProject: PushTest = {
+    name: "IsJekyllProject",
+    mapping: inv => inv.project.hasFile("_config.yml"),
+};
+
+const webNpmCommands: SpawnLogCommand[] = [
+    { command: "npm", args: ["ci"] },
+    { command: "npm", args: ["run", "compile"] },
+];
+
+function spawnCommandString(cmd: SpawnLogCommand): string {
+    return cmd.command + " " + cmd.args.join(" ");
+}
+
+export async function webNpmBuild(project: GitProject, goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> {
+    const siteRoot = await project.getFile("public/index.html");
+    if (siteRoot) {
+        return { code: 0, message: `Site directory already exists in '${project.baseDir}'` };
+    }
+    const log = goalInvocation.progressLog;
+    const opts: SpawnLogOptions = {
+        cwd: project.baseDir,
+        env: { ...process.env, NODE_ENV: "development" },
+        log,
+    };
+    for (const spawnCmd of webNpmCommands) {
+        const res = await spawnLog(spawnCmd.command, spawnCmd.args, opts);
+        if (res.code) {
+            log.write(`Command failed '${spawnCommandString(spawnCmd)}': ${res.error.message}`);
+            return res;
+        }
+    }
+    return { code: 0, message: "Site NPM build successful" };
+}
+
+export const WebNpmBuildAfterCheckout: GoalProjectListenerRegistration = {
+    name: "npm web build",
+    events: [GoalProjectListenerEvent.before],
+    listener: webNpmBuild,
+};
+
+const jekyllCommands: SpawnLogCommand[] = [
+    { command: "bundle", args: ["install"] },
+    { command: "bundle", args: ["exec", "jekyll", "build"] },
+];
+
+export async function jekyllBuild(project: GitProject, goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> {
+    const siteRoot = await project.getFile("_site/index.html");
+    if (siteRoot) {
+        return { code: 0, message: `Site directory already exists in '${project.baseDir}'` };
+    }
+    const log = goalInvocation.progressLog;
+    const opts: SpawnLogOptions = {
+        cwd: project.baseDir,
+        log,
+    };
+    for (const spawnCmd of jekyllCommands) {
+        const res = await spawnLog(spawnCmd.command, spawnCmd.args, opts);
+        if (res.code) {
+            log.write(`Command failed '${spawnCommandString(spawnCmd)}': ${res.error.message}`);
+            return res;
+        }
+    }
+    return { code: 0, message: "Site Jekyll build successful" };
+}
+
+export const JekyllBuildAfterCheckout: GoalProjectListenerRegistration = {
+    name: "jekyll build",
+    events: [GoalProjectListenerEvent.before],
+    listener: jekyllBuild,
+};
+
+export function webBuilder(sitePath: string): Builder {
+    const commands = (sitePath === "_site") ? jekyllCommands : webNpmCommands;
+    return spawnBuilder({
+        name: "WebBuilder",
+        commands,
+        logInterpreter: LogSuppressor,
+        projectToAppInfo: async (p: Project) => {
+            let version: string;
+            const versionFile = await p.getFile("VERSION");
+            if (versionFile) {
+                version = (await versionFile.getContent()).trim();
+            } else {
+                const pkgFile = await p.getFile("package.json");
+                if (pkgFile) {
+                    const pkg = JSON.parse(await pkgFile.getContent());
+                    version = pkg.version;
+                } else {
+                    version = "0.0.0";
+                }
+            }
+            return {
+                id: p.id as RemoteRepoRef,
+                name: p.name,
+                version,
+            };
+        },
+    });
+}
+
+/**
+ * Run htmltest on `sitePath` and convert results to ReviewComments.
+ *
+ * @param sitePath path to web site relative to root of project
+ * @return function that takes a project and returns ReviewComments
+ */
+function runHtmltest(sitePath: string): CodeInspection<ProjectReview, NoParameters> {
+    return async (p: Project) => {
+        const review: ProjectReview = { repoId: p.id, comments: [] };
+        if (!isLocalProject(p)) {
+            logger.error(`Project ${p.name} is not a local project`);
+            return review;
+        }
+        if (!await p.hasDirectory(sitePath)) {
+            logger.error(`Project ${p.name} does not have site directory '${sitePath}'`);
+            return review;
+        }
+        const absPath = path.join(p.baseDir, sitePath);
+        logger.debug(`Running htmltest on ${absPath}`);
+        try {
+            const result = await execPromise("htmltest", [absPath]);
+            if (result.stderr) {
+                logger.debug(`htmltest standard error from ${p.name}: ${result.stderr}`);
+            }
+            logger.debug(`htmltest standard output from ${p.name}: ${result.stdout}`);
+            const comments = await mapHtmltestResultsToReviewComments(p.baseDir);
+            review.comments.push(...comments);
+        } catch (e) {
+            logger.error(`Failed to run htmltest: ${e.message}`);
+        }
+        return review;
+    };
+}
+
+export function htmltestInspection(sitePath: string): CodeInspectionRegistration<ProjectReview, NoParameters> {
+    return {
+        name: "RunHtmltest",
+        description: "Run htmltest on website",
+        inspection: runHtmltest(sitePath),
+        intent: "htmltest",
+    };
+}
+
+/**
+ * Convert the output of htmltest to proper ReviewComments.  If any
+ * part of the process fails, an empty array is returned.
+ *
+ * @param output string output from running `htmltest` that will be parsed and converted.
+ * @return htmltest errors and warnings as ReviewComments
+ */
+export async function mapHtmltestResultsToReviewComments(baseDir: string): Promise<ReviewComment[]> {
+    const logFile = path.join(baseDir, "tmp", ".htmltest", "htmltest.log");
+    const logContent = await fs.readFile(logFile, "utf8");
+    return htmltestLogToReviewComments(logContent);
+}
+
+/**
+ * Testable unit of mapHtmltestResultsToReviewComments.
+ */
+export function htmltestLogToReviewComments(logContent: string): ReviewComment[] {
+    const resultRegExp = /^(.*?)\s+---\s+(.*?)\s+-->\s+(.*?)$/;
+    const comments = logContent.split("\n").map(r => r.trim()).filter(r => r).map(r => {
+        const matches = resultRegExp.exec(r);
+        if (!matches) {
+            logger.warn(`Failed to match htmltest output line '${r}': ${JSON.stringify(matches)}`);
+            return undefined;
+        }
+        const [description, sourcePath, detail] = matches.slice(1);
+        const sourceLocation: SourceLocation = {
+            path: sourcePath,
+            offset: 0,
+        };
+        const severity: Severity = (description === "target does not exist") ? "error" : "warn";
+        return {
+            category: "htmltest",
+            detail,
+            severity,
+            sourceLocation,
+            subcategory: description,
+        };
+    }).filter(r => r);
+    return comments;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,11 +43,6 @@
         "@apollographql/graphql-language-service-types": "^2.0.0"
       }
     },
-    "@apollographql/graphql-playground-html": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@apollographql/graphql-playground-html/-/graphql-playground-html-1.6.6.tgz",
-      "integrity": "sha512-lqK94b+caNtmKFs5oUVXlSpN3sm5IXZ+KfhMxOtr0LR2SqErzkoJilitjDvJ1WbjHlxLI7WtCjRmOLdOGJqtMQ=="
-    },
     "@atomist/antlr": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@atomist/antlr/-/antlr-1.0.2.tgz",
@@ -173,34 +168,10 @@
         "ws": "^6.2.0"
       },
       "dependencies": {
-        "@atomist/microgrammar": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.2.0.tgz",
-          "integrity": "sha512-IW6cU4XjbCTIFAKvyxv8hMkirriWNHvUsSOsKZsmmwf2CxB1TV4POiL+fKAR8NUF/cKQguw1J0MhHlHWzUBK7Q==",
-          "requires": {
-            "json-stringify-safe": "^5.0.1",
-            "stringify-tree": "^1.0.2"
-          }
-        },
-        "@atomist/slack-messages": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@atomist/slack-messages/-/slack-messages-1.1.0.tgz",
-          "integrity": "sha512-sai3gxAyFXVBa7A7AADdVcO8Nw0gV+bXHY9T4Ki447gqbMpAyyVj3V2qxY6wmdI9j5EcwPl0fOaBpFN3xEJTkw=="
-        },
-        "@atomist/tree-path": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/@atomist/tree-path/-/tree-path-1.0.3.tgz",
-          "integrity": "sha512-uZCuGl1ymm/e35FzNAckwYdG6yCMzAjs+0NYJ5BLTjUnEX3KM6ov/SR14eovPdq83wJBFIWbZ0N9NIDhCMobDA==",
-          "requires": {
-            "@atomist/microgrammar": "^1.2.0",
-            "@types/lodash": "^4.14.123",
-            "lodash": "^4.17.11"
-          }
-        },
         "@types/node": {
-          "version": "11.11.3",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.11.3.tgz",
-          "integrity": "sha512-wp6IOGu1lxsfnrD+5mX6qwSwWuqsdkKKxTN4aQc4wByHAKZJf9/D4KXPQ1POUjEbnCP5LMggB0OEFNY9OTsMqg=="
+          "version": "11.13.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+          "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng=="
         }
       }
     },
@@ -398,12 +369,6 @@
         "yargs": "^12.0.1"
       },
       "dependencies": {
-        "@atomist/microgrammar": {
-          "version": "1.0.4",
-          "resolved": "https://registry.npmjs.org/@atomist/microgrammar/-/microgrammar-1.0.4.tgz",
-          "integrity": "sha512-NBQc20oMOypEJNxRYDIPPV+VJg8GuX9AkJxdKwMWgeZSyYx3+0fumYnV/r9+fFlLacFG5zAIpgc/iw1F5Z66jQ==",
-          "dev": true
-        },
         "@types/marked": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.5.0.tgz",
@@ -411,9 +376,9 @@
           "dev": true
         },
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
           "dev": true
         },
         "execa": {
@@ -462,9 +427,9 @@
           "dev": true
         },
         "mem": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/mem/-/mem-4.2.0.tgz",
-          "integrity": "sha512-5fJxa68urlY0Ir8ijatKa3eRz5lwXnRCTvo9+TbTGAuTFJOwpGcY0X05moBd0nW45965Njt4CDI2GFQoG8DvqA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
           "dev": true,
           "requires": {
             "map-age-cleaner": "^0.1.1",
@@ -473,9 +438,9 @@
           }
         },
         "mimic-fn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.0.0.tgz",
-          "integrity": "sha512-jbex9Yd/3lmICXwYT6gA/j2mNQGU48wCh/VzRd+/Y/PjYQtlg1gLMdZqvu9s/xH7qKvngxRObl56XZR609IMbA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
           "dev": true
         },
         "os-locale": {
@@ -703,29 +668,6 @@
         "lodash": "^4.17.11",
         "p-retry": "^3.0.0",
         "ts-essentials": "^1.0.2"
-      },
-      "dependencies": {
-        "@kubernetes/client-node": {
-          "version": "0.8.2",
-          "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.8.2.tgz",
-          "integrity": "sha512-crS3h59+fOGXQgxVdq3XH81ytY7FV2HnB5z/+lSWD3bi5D5lHKu3PVN2PHCDMNExPy0KthcfqBoIVFVy4CoG3A==",
-          "requires": {
-            "@types/js-yaml": "^3.11.2",
-            "@types/node": "^10.12.0",
-            "@types/request": "^2.47.1",
-            "@types/underscore": "^1.8.9",
-            "@types/ws": "^6.0.1",
-            "byline": "^5.0.0",
-            "isomorphic-ws": "^4.0.1",
-            "js-yaml": "^3.12.0",
-            "jsonpath": "^1.0.0",
-            "request": "^2.88.0",
-            "shelljs": "^0.8.2",
-            "tslib": "^1.9.3",
-            "underscore": "^1.9.1",
-            "ws": "^6.1.0"
-          }
-        }
       }
     },
     "@atomist/sdm-pack-node": {
@@ -783,6 +725,232 @@
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-5.0.0.tgz",
           "integrity": "sha512-N5u9tEFRBUzQDjMKRRt8SHxC/UaqYApPmdF4MMFnICQg3z52onNbnneuro/sWw2rd+eGu9agQOzUbD671Xia7Q=="
+        }
+      }
+    },
+    "@atomist/sdm-pack-s3": {
+      "version": "0.1.0-master.20190319050251",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-s3/-/sdm-pack-s3-0.1.0-master.20190319050251.tgz",
+      "integrity": "sha512-c99ZC+fDb0gwxGDVT6Ng6RjKAqizdVwnAuG9on8rOG0giNb9Ua56lYhZaSufDsG6fhPU+IK/m++LWz/CA8hB3A==",
+      "requires": {
+        "@atomist/sdm-local": "^1.0.5-master.20190315000709",
+        "@atomist/slack-messages": "^1.1.0",
+        "aws-sdk": "^2.409.0",
+        "fs-extra": "^7.0.1",
+        "mime-types": "^2.1.22"
+      },
+      "dependencies": {
+        "@atomist/sdm-local": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/@atomist/sdm-local/-/sdm-local-1.0.5.tgz",
+          "integrity": "sha512-AAT8EpbTrAVnsDSFnPDWScLUfhjwVn6vmD9W+BP+xSlsBO2ZQkgNLcZnl3E3gKPros8KmWc83OIko5EGgYAzzg==",
+          "requires": {
+            "@types/body-parser": "^1.17.0",
+            "@types/express": "^4.16.1",
+            "@types/express-handlebars": "0.0.30",
+            "@types/fs-extra": "^5.0.5",
+            "@types/inquirer": "^0.0.44",
+            "@types/json-stringify-safe": "^5.0.0",
+            "@types/jssha": "^2.0.0",
+            "@types/lodash": "^4.14.123",
+            "@types/marked": "^0.6.3",
+            "@types/node": "^11.11.3",
+            "@types/node-notifier": "0.0.28",
+            "@types/open": "^0.0.29",
+            "@types/serialize-error": "^2.1.0",
+            "@types/sprintf-js": "^1.1.2",
+            "@types/strip-ansi": "^3.0.0",
+            "@types/yargs": "^12.0.9",
+            "ansi.js": "^0.0.5",
+            "axios": "^0.19.0-beta.1",
+            "body-parser": "^1.18.3",
+            "boxen": "^3.0.0",
+            "chalk": "^2.4.2",
+            "express": "^4.16.4",
+            "express-handlebars": "^3.0.2",
+            "file-url": "^2.0.2",
+            "format-date": "^1.0.0",
+            "fs-extra": "^7.0.1",
+            "inquirer": "^6.2.2",
+            "json-stringify-safe": "^5.0.1",
+            "jssha": "^2.3.1",
+            "lodash": "^4.17.11",
+            "marked": "^0.6.1",
+            "marked-terminal": "^3.2.0",
+            "on-new-line": "^1.0.0",
+            "portfinder": "^1.0.20",
+            "serialize-error": "^3.0.0",
+            "simple-node-logger": "^0.93.42",
+            "sprintf-js": "^1.1.2",
+            "strip-ansi": "^5.1.0",
+            "terminal-kit": "^1.27.0",
+            "yargs": "^13.2.2"
+          }
+        },
+        "@types/inquirer": {
+          "version": "0.0.44",
+          "resolved": "https://registry.npmjs.org/@types/inquirer/-/inquirer-0.0.44.tgz",
+          "integrity": "sha512-ugbhy1yBtCz5iTWYF+AGRS/UcMcWicdyHhxl9VaeFYc3ueg0CCssthQLB3rIcIOeGtfG6WPEvHdLu/IjKYfefg==",
+          "requires": {
+            "@types/rx": "*",
+            "@types/through": "*"
+          }
+        },
+        "@types/marked": {
+          "version": "0.6.4",
+          "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.6.4.tgz",
+          "integrity": "sha512-rJe6ToeWAUmR6I7eY87gxb2CTwXKqfwfrkDAr9ododuha9D/d57DWWK0xdtKZ2C6yTdP60pAg5fJwC5PHguzyA=="
+        },
+        "@types/node": {
+          "version": "11.13.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+          "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng=="
+        },
+        "boxen": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/boxen/-/boxen-3.0.0.tgz",
+          "integrity": "sha512-6BI51DCC62Ylgv78Kfn+MHkyPwSlhulks+b+wz7bK1vsTFgbSEy/E1DOxx1wjf/0YdkrfPUMh9NoaW419M7csQ==",
+          "requires": {
+            "ansi-align": "^3.0.0",
+            "camelcase": "^5.0.0",
+            "chalk": "^2.4.2",
+            "cli-boxes": "^2.0.0",
+            "string-width": "^3.0.0",
+            "term-size": "^1.2.0",
+            "widest-line": "^2.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg=="
+        },
+        "cli-boxes": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.0.0.tgz",
+          "integrity": "sha512-P46J1Wf3BVD0E5plybtf6g/NtHYAUlOIt7w3ou/Ova/p7dJPdukPV4yp+BF8dpmnnk45XlMzn+x9kfzyucKzrg=="
+        },
+        "execa": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+          "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+          "requires": {
+            "cross-spawn": "^6.0.0",
+            "get-stream": "^4.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "2.0.5",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "get-stream": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+          "requires": {
+            "pump": "^3.0.0"
+          }
+        },
+        "invert-kv": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+          "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+        },
+        "lcid": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+          "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+          "requires": {
+            "invert-kv": "^2.0.0"
+          }
+        },
+        "marked": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-0.6.1.tgz",
+          "integrity": "sha512-+H0L3ibcWhAZE02SKMqmvYsErLo4EAVJxu5h3bHBBDvvjeWXtl92rGUSBYHL2++5Y+RSNgl8dYOAXcYe7lp1fA=="
+        },
+        "mem": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+          "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+          "requires": {
+            "map-age-cleaner": "^0.1.1",
+            "mimic-fn": "^2.0.0",
+            "p-is-promise": "^2.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "os-locale": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+          "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+          "requires": {
+            "execa": "^1.0.0",
+            "lcid": "^2.0.0",
+            "mem": "^4.0.0"
+          }
+        },
+        "p-is-promise": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.0.0.tgz",
+          "integrity": "sha512-pzQPhYMCAgLAKPWD2jC3Se9fEfrD9npNos0y150EeqZll7akhEgGhTW/slB6lHku8AvYGiJ+YJ5hfHKePPgFWg=="
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "y18n": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
+        },
+        "yargs": {
+          "version": "13.2.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+          "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+          "requires": {
+            "cliui": "^4.0.0",
+            "find-up": "^3.0.0",
+            "get-caller-file": "^2.0.1",
+            "os-locale": "^3.1.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^2.0.0",
+            "set-blocking": "^2.0.0",
+            "string-width": "^3.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^4.0.0",
+            "yargs-parser": "^13.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+          "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+          "requires": {
+            "camelcase": "^5.0.0",
+            "decamelize": "^1.2.0"
+          }
         }
       }
     },
@@ -857,11 +1025,11 @@
       }
     },
     "@babel/generator": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.3.4.tgz",
-      "integrity": "sha512-8EXhHRFqlVVWXPezBW5keTiQi/rJMQTg/Y9uVCEZ0CAF3PKtCCaVRnp64Ii1ujhkoDhhF1fVsImoN4yJ2uz4Wg==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.4.0.tgz",
+      "integrity": "sha512-/v5I+a1jhGSKLgZDcmAUZ4K/VePi43eRkUs3yePW1HB1iANOD5tqJXwGSG4BZhSksP8J9ejSlwGeTiiOFZOrXQ==",
       "requires": {
-        "@babel/types": "^7.3.4",
+        "@babel/types": "^7.4.0",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.11",
         "source-map": "^0.5.0",
@@ -887,11 +1055,11 @@
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0.tgz",
-      "integrity": "sha512-MXkOJqva62dfC0w85mEf/LucPPS/1+04nmmRMPEBUB++hiiThQ2zPtX/mEWQ3mtzCEjIJvPY8nuwxXtQeQwUag==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.0.tgz",
+      "integrity": "sha512-7Cuc6JZiYShaZnybDmfwhY4UYHzI6rlqhWjaIqbsJGsIqPimEYy5uh3akSRLMg65LSdSEnJ8a8/bWQN6u2oMGw==",
       "requires": {
-        "@babel/types": "^7.0.0"
+        "@babel/types": "^7.4.0"
       }
     },
     "@babel/highlight": {
@@ -902,57 +1070,43 @@
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
-      },
-      "dependencies": {
-        "js-tokens": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-        }
       }
     },
     "@babel/parser": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.3.4.tgz",
-      "integrity": "sha512-tXZCqWtlOOP4wgCp6RjRvLmfuhnqTLy9VHwRochJBCP2nDm27JnnuFEnXFASVyQNHk36jD1tAammsCEEqgscIQ=="
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.4.3.tgz",
+      "integrity": "sha512-gxpEUhTS1sGA63EGQGuA+WESPR/6tz6ng7tSHFCmaTJK/cGK8y37cBTspX+U2xCAue2IQVvF6Z0oigmjwD8YGQ=="
     },
     "@babel/template": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.2.2.tgz",
-      "integrity": "sha512-zRL0IMM02AUDwghf5LMSSDEz7sBCO2YnNmpg3uWTZj/v1rcG2BmQUvaGU8GhU8BvfMh1k2KIAYZ7Ji9KXPUg7g==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.4.0.tgz",
+      "integrity": "sha512-SOWwxxClTTh5NdbbYZ0BmaBVzxzTh2tO/TeLTbF6MO6EzVhHTnff8CdBXx3mEtazFBoysmEM6GU/wF+SuSx4Fw==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/parser": "^7.2.2",
-        "@babel/types": "^7.2.2"
+        "@babel/parser": "^7.4.0",
+        "@babel/types": "^7.4.0"
       }
     },
     "@babel/traverse": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.3.4.tgz",
-      "integrity": "sha512-TvTHKp6471OYEcE/91uWmhR6PrrYywQntCHSaZ8CM8Vmp+pjAusal4nGB2WCCQd0rvI7nOMKn9GnbcvTUz3/ZQ==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.4.3.tgz",
+      "integrity": "sha512-HmA01qrtaCwwJWpSKpA948cBvU5BrmviAief/b3AVw936DtcdsTexlbyzNuDnthwhOQ37xshn7hvQaEQk7ISYQ==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
-        "@babel/generator": "^7.3.4",
+        "@babel/generator": "^7.4.0",
         "@babel/helper-function-name": "^7.1.0",
-        "@babel/helper-split-export-declaration": "^7.0.0",
-        "@babel/parser": "^7.3.4",
-        "@babel/types": "^7.3.4",
+        "@babel/helper-split-export-declaration": "^7.4.0",
+        "@babel/parser": "^7.4.3",
+        "@babel/types": "^7.4.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.11"
-      },
-      "dependencies": {
-        "globals": {
-          "version": "11.11.0",
-          "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
-          "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw=="
-        }
       }
     },
     "@babel/types": {
-      "version": "7.3.4",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.3.4.tgz",
-      "integrity": "sha512-WEkp8MsLftM7O/ty580wAmZzN1nDmCACc5+jFzUt+GUFNNIi3LdRlueYz0YIlmJhlZx1QYDMZL5vdWCL0fNjFQ==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.4.0.tgz",
+      "integrity": "sha512-aPvkXyU2SPOnztlgo8n9cEiXW755mgyvueUPcpStqdzoSPm0fjO0vQBjLkt3JKJW7ufikfcnMTTPsN1xaTsBPA==",
       "requires": {
         "esutils": "^2.0.2",
         "lodash": "^4.17.11",
@@ -996,7 +1150,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@cronvel/get-pixels/-/get-pixels-3.3.1.tgz",
       "integrity": "sha512-jgDb8vGPkpjRDbiYyHTI2Bna4HJysjPNSiERzBnRJjCR/YqC3u0idTae0tmNECsaZLOpAWmlK9wiIwnLGIT9Bg==",
-      "dev": true,
       "requires": {
         "jpeg-js": "^0.1.1",
         "ndarray": "^1.0.13",
@@ -1081,20 +1234,20 @@
       }
     },
     "@oclif/command": {
-      "version": "1.5.11",
-      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.11.tgz",
-      "integrity": "sha512-jcdCmaShB7k7Lfr+rGvBeTzcCbprTF690n0dv/cB4PmXESfOx/5P4/scDR75mToht+VxOADI0aXMGQJz3T4uMg==",
+      "version": "1.5.12",
+      "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.5.12.tgz",
+      "integrity": "sha512-D5/Kph9smL92X1z9WPmxFd9zDruFsCk4/LbfCaBmiO2Vyyt7Y9O6kI1YLsC3B0KC9wymSCTH14IK96rf9AFHfQ==",
       "requires": {
         "@oclif/errors": "^1.2.2",
-        "@oclif/parser": "^3.7.2",
+        "@oclif/parser": "^3.7.3",
         "debug": "^4.1.1",
         "semver": "^5.6.0"
       }
     },
     "@oclif/config": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.0.tgz",
-      "integrity": "sha512-RB6A+N7Dq5DcFOQEhPpB8DdXtMQm2VDgdtgBKUdot815tj4gW7nDmRZBEwU85x4Xhep7Dx3tpaXobA6bFlSOWg==",
+      "version": "1.12.12",
+      "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.12.tgz",
+      "integrity": "sha512-0vlX5VYvOfF9QbkCqMyPSzH9GMp6at4Mbqn8CxCskxhKvNZoPD5ocda2ku0zEnoqxGAQ4VfQP7NCqJthuiStfg==",
       "requires": {
         "debug": "^4.1.1",
         "tslib": "^1.9.3"
@@ -1202,22 +1355,22 @@
       }
     },
     "@oclif/plugin-plugins": {
-      "version": "1.7.7",
-      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-1.7.7.tgz",
-      "integrity": "sha512-bKHruaqt3MbQefRJUgsaA1B78J69+26kUA28IhB4GlWO7RpNWEBPIAMeBk/fRB4Tfw2ZuLC7T/zwOFzvY5V1Tw==",
+      "version": "1.7.8",
+      "resolved": "https://registry.npmjs.org/@oclif/plugin-plugins/-/plugin-plugins-1.7.8.tgz",
+      "integrity": "sha512-GxLxaf8Lk1RqHVAIBZyA7hmhU7u5oV97i/OsWgFPdjPaT+BmWlWXR8IpmtA8giNo6atR+JpfgDmYndMU75zYUQ==",
       "requires": {
         "@oclif/color": "^0.0.0",
-        "@oclif/command": "^1.5.4",
+        "@oclif/command": "^1.5.12",
         "chalk": "^2.4.2",
-        "cli-ux": "^5.0.0",
+        "cli-ux": "^5.2.1",
         "debug": "^4.1.0",
         "fs-extra": "^7.0.1",
         "http-call": "^5.2.2",
-        "load-json-file": "^5.1.0",
-        "npm-run-path": "^2.0.2",
+        "load-json-file": "^5.2.0",
+        "npm-run-path": "^3.0.0",
         "semver": "^5.6.0",
         "tslib": "^1.9.3",
-        "yarn": "^1.13.0"
+        "yarn": "^1.15.0"
       },
       "dependencies": {
         "clean-stack": {
@@ -1256,6 +1409,19 @@
             "tslib": "^1.9.3"
           }
         },
+        "npm-run-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.0.0.tgz",
+          "integrity": "sha512-42wmNM/F44tq5pDfDDwYWh30JbQokeUn79/6qNyoEvCSOMy0Q2iHe7unLRzRWQL5JLrOoQT6WzSuc6ylvEMmNg==",
+          "requires": {
+            "path-key": "^3.0.0"
+          }
+        },
+        "path-key": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.0.0.tgz",
+          "integrity": "sha512-zLY/S2T5y8zv1vEpx4VHguUgmtgkewofGKSpa7VmzdU3Jbu8JonUvt5hzjBpJvamSnusynqJiYwkbi22aTo7Rw=="
+        },
         "string-width": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
@@ -1282,17 +1448,6 @@
         "http-call": "^5.2.2",
         "lodash.template": "^4.4.0",
         "semver": "^5.6.0"
-      },
-      "dependencies": {
-        "@oclif/config": {
-          "version": "1.12.10",
-          "resolved": "https://registry.npmjs.org/@oclif/config/-/config-1.12.10.tgz",
-          "integrity": "sha512-AQYFA72ktXgmrY4hjRtBQRfKLDKXPG4WGSLUgWn0KencNuqnmbiKS6zfKXf1umfZ26zoDOEfCdqZjm3aNZnIaw==",
-          "requires": {
-            "debug": "^4.1.1",
-            "tslib": "^1.9.3"
-          }
-        }
       }
     },
     "@oclif/screen": {
@@ -1301,9 +1456,9 @@
       "integrity": "sha512-60CHpq+eqnTxLZQ4PGHYNwUX572hgpMHGPtTWMjdTMsAvlm69lZV/4ly6O3sAYkomo4NggGcomrDpBe34rxUqw=="
     },
     "@octokit/endpoint": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.1.3.tgz",
-      "integrity": "sha512-vAWzeoj9Lzpl3V3YkWKhGzmDUoMfKpyxJhpq74/ohMvmLXDoEuAGnApy/7TRi3OmnjyX2Lr+e9UGGAD0919ohA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-3.2.3.tgz",
+      "integrity": "sha512-yUPCt4vMIOclox13CUxzuKiPJIFo46b/6GhUnUTw5QySczN1L0DtSxgmIZrZV4SAb9EyAqrceoyrWoYVnfF2AA==",
       "requires": {
         "deepmerge": "3.2.0",
         "is-plain-object": "^2.0.4",
@@ -1312,11 +1467,11 @@
       }
     },
     "@octokit/request": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.1.tgz",
-      "integrity": "sha512-nN8W24ZXEpJQJoVgMsGZeK9FOzxkc39Xn9ykseUpPpPMNEDFSvqfkCeqqKrjUiXRm72ubGLWG1SOz0aJPcgGww==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.2.tgz",
+      "integrity": "sha512-lxVlYYvwGbKSHXfbPk5vxEA8w4zHOH1wobado4a9EfsyD3Cbhuhus1w0Ye9Ro0eMubGO8kNy5d+xNFisM3Tvaw==",
       "requires": {
-        "@octokit/endpoint": "^3.1.1",
+        "@octokit/endpoint": "^3.2.0",
         "deprecation": "^1.0.1",
         "is-plain-object": "^2.0.4",
         "node-fetch": "^2.3.0",
@@ -1325,11 +1480,12 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.17.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.17.1.tgz",
-      "integrity": "sha512-cRosFoYEXraBsXe+FDHFW4b98RM0WuvSv9HUsbV69E+j8aRGAU/4FudEdpgBSIiXv8HvUOLlo6fAdJmmJHSVKw==",
+      "version": "16.23.2",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.23.2.tgz",
+      "integrity": "sha512-ZxiZMaCuqBG/IsbgNRVfGwYsvBb5DjHuMGjJgOrinT+/b+1j1U7PiGyRkHDJdjTGA6N/PsMC2lP2ZybX9579iA==",
       "requires": {
-        "@octokit/request": "2.4.1",
+        "@octokit/request": "2.4.2",
+        "atob-lite": "^2.0.0",
         "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
         "deprecation": "^1.0.1",
@@ -1341,60 +1497,6 @@
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       }
-    },
-    "@protobufjs/aspromise": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
-      "integrity": "sha1-m4sMxmPWaafY9vXQiToU00jzD78="
-    },
-    "@protobufjs/base64": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
-      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg=="
-    },
-    "@protobufjs/codegen": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-      "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg=="
-    },
-    "@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha1-NVy8mLr61ZePntCV85diHx0Ga3A="
-    },
-    "@protobufjs/fetch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-      "integrity": "sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.1",
-        "@protobufjs/inquire": "^1.1.0"
-      }
-    },
-    "@protobufjs/float": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
-      "integrity": "sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E="
-    },
-    "@protobufjs/inquire": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-      "integrity": "sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik="
-    },
-    "@protobufjs/path": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
-      "integrity": "sha1-bMKyDFya1q0NzP0hynZz2Nf79o0="
-    },
-    "@protobufjs/pool": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
-      "integrity": "sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q="
-    },
-    "@protobufjs/utf8": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
-      "integrity": "sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA="
     },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
@@ -1520,13 +1622,12 @@
     "@types/express-handlebars": {
       "version": "0.0.30",
       "resolved": "https://registry.npmjs.org/@types/express-handlebars/-/express-handlebars-0.0.30.tgz",
-      "integrity": "sha512-fAsX3nJ9jhJhUzpQlb8Wm62UxrFZ58/87EPuMIt9E2unZrEPp5JhH3GdFZyRBxH4TmMoyPctIOZBqrZRj3Carg==",
-      "dev": true
+      "integrity": "sha512-fAsX3nJ9jhJhUzpQlb8Wm62UxrFZ58/87EPuMIt9E2unZrEPp5JhH3GdFZyRBxH4TmMoyPctIOZBqrZRj3Carg=="
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.1.tgz",
-      "integrity": "sha512-QgbIMRU1EVRry5cIu1ORCQP4flSYqLM1lS5LYyGWfKnFT3E58f0gKto7BR13clBFVrVZ0G0rbLZ1hUpSkgQQOA==",
+      "version": "4.16.2",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.2.tgz",
+      "integrity": "sha512-qgc8tjnDrc789rAQed8NoiFLV5VGcItA4yWNFphqGU0RcuuQngD00g3LHhWIK3HQ2XeDgVCmlNPDlqi3fWBHnQ==",
       "requires": {
         "@types/node": "*",
         "@types/range-parser": "*"
@@ -1569,14 +1670,17 @@
       }
     },
     "@types/graphql": {
-      "version": "14.0.7",
-      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.0.7.tgz",
-      "integrity": "sha512-BoLDjdvLQsXPZLJux3lEZANwGr3Xag56Ngy0U3y8uoRSDdeLcn43H3oBcgZlnd++iOQElBpaRVDHPzEDekyvXQ=="
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/@types/graphql/-/graphql-14.2.0.tgz",
+      "integrity": "sha512-lELg5m6eBOmATWyCZl8qULEOvnPIUG6B443yXKj930glXIgwQirIBPp5rthP2amJW0YSzUg2s5sfgba4mRRCNw=="
     },
     "@types/handlebars": {
-      "version": "4.0.39",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.39.tgz",
-      "integrity": "sha512-vjaS7Q0dVqFp85QhyPSZqDKnTTCemcSHNHFvDdalO1s0Ifz5KuE64jQD5xoUkfdWwF4WpqdJEl7LsWH8rzhKJA=="
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.1.0.tgz",
+      "integrity": "sha512-gq9YweFKNNB1uFK71eRqsd4niVkXrxHugqWFQkeLRJvGjnxsLr16bYtcsG4tOFwmYi0Bax+wCkbf1reUfdl4kA==",
+      "requires": {
+        "handlebars": "*"
+      }
     },
     "@types/hasha": {
       "version": "3.0.1",
@@ -1638,11 +1742,6 @@
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
       "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q=="
     },
-    "@types/long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-1w52Nyx4Gq47uuu0EVcsHBxZFJgurQ+rTKS3qMHxR1GY2T8c2AJYd6vZoZ9q1rupaDjU0yT+Jc2XTyXkjeMA+Q=="
-    },
     "@types/marked": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@types/marked/-/marked-0.4.2.tgz",
@@ -1665,15 +1764,14 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.1.tgz",
-      "integrity": "sha512-Rymt08vh1GaW4vYB6QP61/5m/CFLGnFZP++bJpWbiNxceNa6RBipDmb413jvtSf/R1gg5a/jQVl2jY4XVRscEA=="
+      "version": "10.14.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.4.tgz",
+      "integrity": "sha512-DT25xX/YgyPKiHFOpNuANIQIVvYEwCWXgK2jYYwqgaMrYE6+tq+DtmMwlD3drl6DJbUwtlIDnn0d7tIn/EbXBg=="
     },
     "@types/node-notifier": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/@types/node-notifier/-/node-notifier-0.0.28.tgz",
       "integrity": "sha1-hro9OqjZGDUswxkdiN4yiyDck8E=",
-      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -1681,8 +1779,7 @@
     "@types/open": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/open/-/open-0.0.29.tgz",
-      "integrity": "sha1-PekQASZ0kJ2xTWCNH95E/6ep7Oo=",
-      "dev": true
+      "integrity": "sha1-PekQASZ0kJ2xTWCNH95E/6ep7Oo="
     },
     "@types/p-retry": {
       "version": "2.0.0",
@@ -1909,9 +2006,9 @@
       }
     },
     "@types/shelljs": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.3.tgz",
-      "integrity": "sha512-miY41hqc5SkRlsZDod3heDa4OS9xv8G77EMBQuSpqq86HBn66l7F+f8y9YKm+1PIuwC8QEZVwN8YxOOG7Y67fA==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/@types/shelljs/-/shelljs-0.8.4.tgz",
+      "integrity": "sha512-UNACC6scKFVljWEvO3rHBkbbKXu3QkKPBOMCisxI7au9cnFK7tjOGPsKh5OjedAPLmtsKSarmk+YeehKTQSKtg==",
       "requires": {
         "@types/glob": "*",
         "@types/node": "*"
@@ -2012,10 +2109,9 @@
       "integrity": "sha1-0DTh0ynkbo0Pc3yajbl/aPgbU4I="
     },
     "@types/yargs": {
-      "version": "12.0.9",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.9.tgz",
-      "integrity": "sha512-sCZy4SxP9rN2w30Hlmg5dtdRwgYQfYRiLo9usw8X9cxlf+H4FqM1xX7+sNH7NNKVdbXMJWqva7iyy+fxh/V7fA==",
-      "dev": true
+      "version": "12.0.11",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-12.0.11.tgz",
+      "integrity": "sha512-IsU1TD+8cQCyG76ZqxP0cVFnofvfzT8p/wO8ENT4jbN/KKN3grsHFgHNl/U+08s33ayX4LwI85cEhYXCOlOkMw=="
     },
     "@types/zen-observable": {
       "version": "0.8.0",
@@ -2089,7 +2185,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
       "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
-      "dev": true,
       "requires": {
         "string-width": "^3.0.0"
       },
@@ -2098,7 +2193,6 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
           "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "dev": true,
           "requires": {
             "emoji-regex": "^7.0.1",
             "is-fullwidth-code-point": "^2.0.0",
@@ -2129,7 +2223,6 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/ansi.js/-/ansi.js-0.0.5.tgz",
       "integrity": "sha1-4+nkXraXe6Du7u0RZ30SFEZ1NIw=",
-      "dev": true,
       "requires": {
         "on-new-line": "0.0.1"
       },
@@ -2137,8 +2230,7 @@
         "on-new-line": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/on-new-line/-/on-new-line-0.0.1.tgz",
-          "integrity": "sha1-mTOcsG3P4+eNaWSi7yrzdKFF+Ps=",
-          "dev": true
+          "integrity": "sha1-mTOcsG3P4+eNaWSi7yrzdKFF+Ps="
         }
       }
     },
@@ -2167,27 +2259,27 @@
       }
     },
     "apollo": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.6.2.tgz",
-      "integrity": "sha512-X2UBTvVvtnbqjlQo8mick091Kwj5BI70rhnDjT9QxljI9b7Zs4ISc2nNt1RWeMo3wjf4zXunMsHu+SO4qktyxg==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/apollo/-/apollo-2.7.0.tgz",
+      "integrity": "sha512-SNFUMoHe/HKK/rcjRphSKQJTdXznJX+9bAcsqkr0LEUTbH2cnoUsMvTqDjlHpFxo8m/WL1LsWnuWz67Dq522uA==",
       "requires": {
         "@apollographql/apollo-tools": "0.3.5",
-        "@oclif/command": "1.5.11",
-        "@oclif/config": "1.12.0",
+        "@oclif/command": "1.5.12",
+        "@oclif/config": "1.12.12",
         "@oclif/errors": "1.2.2",
         "@oclif/plugin-autocomplete": "0.1.0",
         "@oclif/plugin-help": "2.1.6",
         "@oclif/plugin-not-found": "1.2.2",
-        "@oclif/plugin-plugins": "1.7.7",
+        "@oclif/plugin-plugins": "1.7.8",
         "@oclif/plugin-warn-if-update-available": "1.7.0",
-        "apollo-codegen-core": "0.32.10",
-        "apollo-codegen-flow": "0.32.10",
-        "apollo-codegen-scala": "0.33.6",
-        "apollo-codegen-swift": "0.32.10",
-        "apollo-codegen-typescript": "0.32.11",
-        "apollo-engine-reporting": "0.2.2",
+        "apollo-codegen-core": "0.33.0",
+        "apollo-codegen-flow": "0.33.0",
+        "apollo-codegen-scala": "0.34.0",
+        "apollo-codegen-swift": "0.33.0",
+        "apollo-codegen-typescript": "0.33.0",
         "apollo-env": "0.4.0",
-        "apollo-language-server": "1.5.4",
+        "apollo-graphql": "0.2.0",
+        "apollo-language-server": "1.6.0",
         "chalk": "2.4.2",
         "cli-ux": "4.9.3",
         "env-ci": "3.2.0",
@@ -2211,25 +2303,6 @@
       "requires": {
         "apollo-utilities": "^1.2.1",
         "tslib": "^1.9.3"
-      }
-    },
-    "apollo-cache-control": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/apollo-cache-control/-/apollo-cache-control-0.4.1.tgz",
-      "integrity": "sha512-1wGSlIkL1V4S8qmwnWL96F9kq3m4WTeFVUtZ/L2M5BsKkl74YqLa8+UzORJyGE3rfyRbAGa3qg7p21f/DgeezA==",
-      "requires": {
-        "apollo-server-env": "2.2.0",
-        "graphql-extensions": "0.4.2"
-      },
-      "dependencies": {
-        "graphql-extensions": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.2.tgz",
-          "integrity": "sha512-a8SD/dlwkg/ujdcf8WnB1RRqgwheSLtY4/Zf5PFZ/nw42ZvD9m9f+tFovUhy1cw25PqQG/MI4xrfDyMy+J7Log==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.3.0"
-          }
-        }
       }
     },
     "apollo-cache-inmemory": {
@@ -2281,28 +2354,28 @@
       }
     },
     "apollo-codegen-core": {
-      "version": "0.32.10",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.32.10.tgz",
-      "integrity": "sha512-AgC0Yj40PxoL0R3DoyvKGuwxelT3Rsbz1TPcvWJiHqeVBI77Ha01SIp+st9rXlbofHjSxfFC6cJBNrZEu/Cbow==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-core/-/apollo-codegen-core-0.33.0.tgz",
+      "integrity": "sha512-h82nKbhHcwcYl+NoQxhj97AgWhjy9yZ9KURs+MYzUJnRQbKrk0yKbTwkuMLoE9/nppWzbrJPg8Yv14OhIdKqqw==",
       "requires": {
-        "@babel/generator": "7.3.4",
+        "@babel/generator": "7.4.0",
         "@babel/parser": "^7.1.3",
-        "@babel/types": "7.3.4",
+        "@babel/types": "7.4.0",
         "apollo-env": "0.4.0",
-        "apollo-language-server": "1.5.4",
+        "apollo-language-server": "1.6.0",
         "ast-types": "^0.12.0",
         "common-tags": "^1.5.1",
         "recast": "^0.17.0"
       }
     },
     "apollo-codegen-flow": {
-      "version": "0.32.10",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.32.10.tgz",
-      "integrity": "sha512-4PjAKTPyatgI4/GNF972kz5Sw9XX4bnqxj6Sdcc8IqK+TGMSSVVJgCEpEZqMBrmGoMrWsuxP+WqeNqgmmQzlSg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-flow/-/apollo-codegen-flow-0.33.0.tgz",
+      "integrity": "sha512-GhgZa8n8mAfk+ni+y6LAms0U3aLYCujwGkOuNySuR/KaIUwFSXqq/9qrd3UMpfnxAv2x8v65FfnHSJdtCSwaZw==",
       "requires": {
-        "@babel/generator": "7.3.4",
-        "@babel/types": "7.3.4",
-        "apollo-codegen-core": "0.32.10",
+        "@babel/generator": "7.4.0",
+        "@babel/types": "7.4.0",
+        "apollo-codegen-core": "0.33.0",
         "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -2310,11 +2383,11 @@
       }
     },
     "apollo-codegen-scala": {
-      "version": "0.33.6",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.33.6.tgz",
-      "integrity": "sha512-XBALM0c+E4FjX5eZY3lVHnZ4YREx4cNbaM6U9Lv+wvx8jGq1FLyRuGlLqNYB21sOV7MfKjiPUUGiJniitGt2rA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-scala/-/apollo-codegen-scala-0.34.0.tgz",
+      "integrity": "sha512-7mWxzRYfxtctfCzSlfQVtjjoH/geM1alER3riGksJiJ/USFP46rbDstKkyO81gRqj8n7EL7LW98DLPrC3sxrAg==",
       "requires": {
-        "apollo-codegen-core": "0.32.10",
+        "apollo-codegen-core": "0.33.0",
         "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -2322,11 +2395,11 @@
       }
     },
     "apollo-codegen-swift": {
-      "version": "0.32.10",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.32.10.tgz",
-      "integrity": "sha512-J1WSLQPLjmEFzyZ9QgRRYsKgZZdYBtiQmDqu243QvqBNGYwn4eqUdMZIP1hi+jzEdS/3fdYyiTAFZ41NcH6TCw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-swift/-/apollo-codegen-swift-0.33.0.tgz",
+      "integrity": "sha512-gOYa6EYhMIlE383eTZp1ytLwN4x+8+g/l/rzdQSm/mi+YeF8P+Zk7ir43ZJAMMQdrMHzMlrLZs8b3kEOuY/pdQ==",
       "requires": {
-        "apollo-codegen-core": "0.32.10",
+        "apollo-codegen-core": "0.33.0",
         "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -2334,13 +2407,13 @@
       }
     },
     "apollo-codegen-typescript": {
-      "version": "0.32.11",
-      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.32.11.tgz",
-      "integrity": "sha512-HMohdep3Q5aO9/bSROC/L30TRV5maMHFkZQs50MpN4GHG5+tdJqR1YROqa//HDjYzDPczNVaffieKYR2YgOB9A==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/apollo-codegen-typescript/-/apollo-codegen-typescript-0.33.0.tgz",
+      "integrity": "sha512-vWGkGCv5g1pFVvWBWo/toCBQU+DfGalmAgcx7YYTf+NRk8FudGsYrBdTIJYPgqv+0ArMB+q3LdMNe07gpuFwGQ==",
       "requires": {
-        "@babel/generator": "7.3.4",
-        "@babel/types": "7.3.4",
-        "apollo-codegen-core": "0.32.10",
+        "@babel/generator": "7.4.0",
+        "@babel/types": "7.4.0",
+        "apollo-codegen-core": "0.33.0",
         "apollo-env": "0.4.0",
         "change-case": "^3.0.1",
         "common-tags": "^1.5.1",
@@ -2356,27 +2429,6 @@
         "apollo-server-env": "2.2.0"
       }
     },
-    "apollo-engine-reporting": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting/-/apollo-engine-reporting-0.2.2.tgz",
-      "integrity": "sha512-EiTw/VPLjL7X3EKV21jpr44nRaMv0xGvcbBxc2q6fEaa95tU/QTkwtQv+/3sTaH20+fIY2Rjlo8y6MzKZ3bNdw==",
-      "requires": {
-        "apollo-engine-reporting-protobuf": "0.2.0",
-        "apollo-server-core": "2.3.4",
-        "apollo-server-env": "2.2.0",
-        "async-retry": "^1.2.1",
-        "graphql-extensions": "0.4.3",
-        "lodash": "^4.17.10"
-      }
-    },
-    "apollo-engine-reporting-protobuf": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/apollo-engine-reporting-protobuf/-/apollo-engine-reporting-protobuf-0.2.0.tgz",
-      "integrity": "sha512-qI+GJKN78UMJ9Aq/ORdiM2qymZ5yswem+/VDdVFocq+/e1QqxjnpKjQWISkswci5+WtpJl9SpHBNxG98uHDKkA==",
-      "requires": {
-        "protobufjs": "^6.8.6"
-      }
-    },
     "apollo-env": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/apollo-env/-/apollo-env-0.4.0.tgz",
@@ -2387,10 +2439,19 @@
         "sha.js": "^2.4.11"
       }
     },
+    "apollo-graphql": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/apollo-graphql/-/apollo-graphql-0.2.0.tgz",
+      "integrity": "sha512-wwKynD31Yw1L93IAtnEyhSxBhK4X7NXqkY6wBKWRQ4xph5uJKGgmcQmq3sPieKJT91BGL4AQBv+cwGD3blbLNA==",
+      "requires": {
+        "apollo-env": "0.4.0",
+        "lodash.sortby": "^4.7.0"
+      }
+    },
     "apollo-language-server": {
-      "version": "1.5.4",
-      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.5.4.tgz",
-      "integrity": "sha512-KPaddk9FJQPE6qenAJ83jM/KcIxugbEPuquWWUPtGOSkSRjiPR2dz47Uuw1z7Gtvxq3RR0c29PgDdx+CHK/QyA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/apollo-language-server/-/apollo-language-server-1.6.0.tgz",
+      "integrity": "sha512-V7I2DXFGeErmmKxstV+KU17GQq6mpbNMR4hwB4rBXTdbrQucWoEfg4aE1y0BaQv187AMZrvRFiu2u9ZlVaF+JA==",
       "requires": {
         "@apollographql/apollo-tools": "0.3.5",
         "@apollographql/graphql-language-service-interface": "^2.0.2",
@@ -2406,7 +2467,7 @@
         "await-to-js": "^2.0.1",
         "core-js": "3.0.0-beta.13",
         "cosmiconfig": "^5.0.6",
-        "dotenv": "^6.1.0",
+        "dotenv": "^7.0.0",
         "glob": "^7.1.3",
         "graphql": "^14.0.2",
         "graphql-tag": "^2.10.1",
@@ -2497,57 +2558,6 @@
         "lru-cache": "^5.0.0"
       }
     },
-    "apollo-server-core": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.3.4.tgz",
-      "integrity": "sha512-fVnF1V6iVxstRUmtTPmNFgIelRBtEDS4/doLxdOjtNMGrec46KT0LSTU3xaC4Xsv0iY0DlSHtochZsX7ojznBg==",
-      "requires": {
-        "@apollographql/apollo-tools": "^0.3.0",
-        "@apollographql/graphql-playground-html": "^1.6.6",
-        "@types/ws": "^6.0.0",
-        "apollo-cache-control": "0.4.1",
-        "apollo-datasource": "0.2.2",
-        "apollo-engine-reporting": "0.2.2",
-        "apollo-server-caching": "0.2.2",
-        "apollo-server-env": "2.2.0",
-        "apollo-server-errors": "2.2.0",
-        "apollo-server-plugin-base": "0.2.3",
-        "apollo-tracing": "0.4.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "graphql-extensions": "0.4.3",
-        "graphql-subscriptions": "^1.0.0",
-        "graphql-tag": "^2.9.2",
-        "graphql-tools": "^4.0.0",
-        "graphql-upload": "^8.0.2",
-        "lodash": "^4.17.10",
-        "subscriptions-transport-ws": "^0.9.11",
-        "ws": "^6.0.0"
-      },
-      "dependencies": {
-        "apollo-datasource": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/apollo-datasource/-/apollo-datasource-0.2.2.tgz",
-          "integrity": "sha512-CB9XnZTQHhP9W7IWZH/bR/7/aelMrRdDJ8uoAz59buXbFlb5ExZa/54FGZg7g6q+JQGeFaquMAR1QZb2kfuC9w==",
-          "requires": {
-            "apollo-server-caching": "0.2.2",
-            "apollo-server-env": "2.2.0"
-          }
-        },
-        "apollo-server-caching": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/apollo-server-caching/-/apollo-server-caching-0.2.2.tgz",
-          "integrity": "sha512-EYNSR1Vubd14REonCRTJaO/Gr4lkjUTt/45Wp+f1DQtfsAZpHxAtCWafX5fesvq8krdHhSHyEUOTjj2JO8Qi9w==",
-          "requires": {
-            "lru-cache": "^5.0.0"
-          }
-        },
-        "apollo-server-errors": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.2.0.tgz",
-          "integrity": "sha512-gV9EZG2tovFtT1cLuCTavnJu2DaKxnXPRNGSTo+SDI6IAk6cdzyW0Gje5N2+3LybI0Wq5KAbW6VLei31S4MWmg=="
-        }
-      }
-    },
     "apollo-server-env": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/apollo-server-env/-/apollo-server-env-2.2.0.tgz",
@@ -2561,30 +2571,6 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.2.1.tgz",
       "integrity": "sha512-wY/YE3iJVMYC+WYIf8QODBjIP4jhI+oc7kiYo9mrz7LdYPKAgxr/he+NteGcqn/0Ea9K5/ZFTGJDbEstSMeP8g=="
-    },
-    "apollo-server-plugin-base": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-plugin-base/-/apollo-server-plugin-base-0.2.3.tgz",
-      "integrity": "sha512-NCJUAtr2lnV27pwqQEF2NTyT0yuaJ6qJbBSovtViEf38eXvxTPEXRE2Fg4uELrAVcxKfzQKaCzCScm5iFCcf6A=="
-    },
-    "apollo-tracing": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/apollo-tracing/-/apollo-tracing-0.4.1.tgz",
-      "integrity": "sha512-XQZjhW5gs0EvZityJJuqskeUdJMiuDCt9e5+NqKWlvNaxVhNBUChUpAT4Lkh1RHai2rfFjrW1oCNMZMfC86Sqw==",
-      "requires": {
-        "apollo-server-env": "2.2.0",
-        "graphql-extensions": "0.4.2"
-      },
-      "dependencies": {
-        "graphql-extensions": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.2.tgz",
-          "integrity": "sha512-a8SD/dlwkg/ujdcf8WnB1RRqgwheSLtY4/Zf5PFZ/nw42ZvD9m9f+tFovUhy1cw25PqQG/MI4xrfDyMy+J7Log==",
-          "requires": {
-            "@apollographql/apollo-tools": "^0.3.0"
-          }
-        }
-      }
     },
     "apollo-utilities": {
       "version": "1.2.1",
@@ -2607,9 +2593,9 @@
       }
     },
     "app-root-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.1.0.tgz",
-      "integrity": "sha1-mL9lmTJ+zqGZMJhm6BQDaP0uZGo="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.2.1.tgz",
+      "integrity": "sha512-91IFKeKk7FjfmezPKkwtaRvSpnUc4gDwPAjA1YZ9Gn0q0PPeW+vbeUsZuyDwjI7+QTHhcLen2v25fi/AmhvbJA=="
     },
     "arg": {
       "version": "4.1.0",
@@ -2740,9 +2726,9 @@
       "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
     },
     "ast-types": {
-      "version": "0.12.2",
-      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.2.tgz",
-      "integrity": "sha512-8c83xDLJM/dLDyXNLiR6afRRm4dPKN6KAnKqytRK3DBJul9lA+atxdQkNDkSVPdTqea5HiRq3lnnOIZ0MBpvdg=="
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.12.3.tgz",
+      "integrity": "sha512-wJUcAfrdW+IgDoMGNz5MmcvahKgB7BwIbLupdKVVHxHNYt+HVR2k35swdYNv9aZpF8nvlkjbnkp2rrNwxGckZA=="
     },
     "async": {
       "version": "2.6.2",
@@ -2767,21 +2753,6 @@
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
-    "async-retry": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.2.3.tgz",
-      "integrity": "sha512-tfDb02Th6CE6pJUF2gjW5ZVjsgwlucVXOEQMvEX9JgSJMs9gAX+Nz3xRuJBKuUYjTSYORqvDBORdAQ3LU59g7Q==",
-      "requires": {
-        "retry": "0.12.0"
-      },
-      "dependencies": {
-        "retry": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
-        }
-      }
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2792,10 +2763,58 @@
       "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
+    "atob-lite": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/atob-lite/-/atob-lite-2.0.0.tgz",
+      "integrity": "sha1-D+9a1G8b16hQLGVyfwNn1e5D1pY="
+    },
     "await-to-js": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/await-to-js/-/await-to-js-2.1.1.tgz",
       "integrity": "sha512-CHBC6gQGCIzjZ09tJ+XmpQoZOn4GdWePB4qUweCaKNJ0D3f115YdhmYVTZ4rMVpiJ3cFzZcTYK1VMYEICV4YXw=="
+    },
+    "aws-sdk": {
+      "version": "2.434.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.434.0.tgz",
+      "integrity": "sha512-RoMEKsY5XHxdJCyYC80OPPNRJHfnaNGxAD8fsRpbRmkzhBncK8ukHrw3qPZFALrMlp+QTO5Wx/RaAI217QNNSw==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "4.9.1",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+          "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4",
+            "isarray": "^1.0.0"
+          }
+        },
+        "events": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+          "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
+        "ieee754": {
+          "version": "1.1.8",
+          "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+          "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "sax": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+          "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+        }
+      }
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -2855,6 +2874,11 @@
             "strip-ansi": "^3.0.0",
             "supports-color": "^2.0.0"
           }
+        },
+        "js-tokens": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -2956,6 +2980,11 @@
           "requires": {
             "ms": "2.0.0"
           }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
         },
         "ms": {
           "version": "2.0.0",
@@ -3078,9 +3107,9 @@
       "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
     },
     "binary-extensions": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.0.tgz",
-      "integrity": "sha512-EgmjVLMn22z7eGGv3kcnHwSnJXmFHjISTY9E/S5lIcTD3Oxw05QTcBLNkJFzcb3cNueUdF/IN4U+d78V0zO8Hw=="
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+      "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw=="
     },
     "bl": {
       "version": "1.2.2",
@@ -3121,26 +3150,10 @@
             "ms": "2.0.0"
           }
         },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         }
       }
     },
@@ -3168,9 +3181,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
-          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.0.tgz",
+          "integrity": "sha512-Y05ICatFYPAfykDIB7VdwSJ0LUl1yq/BwO2OpyGGLjiRe1fgzTwVypPiWnzkGFOVFHXrCXUNBl86bpjBhZWSJg==",
           "dev": true
         },
         "string-width": {
@@ -3290,14 +3303,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-    },
-    "busboy": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.3.0.tgz",
-      "integrity": "sha512-e+kzZRAbbvJPLjQz2z+zAyr78BSi9IFeBTyLwF76g78Q2zRt/RZ1NtS3MS17v2yLqYfLz69zHdC+1L4ja8PwqQ==",
-      "requires": {
-        "dicer": "0.3.0"
-      }
     },
     "byline": {
       "version": "5.0.0",
@@ -3565,9 +3570,9 @@
       },
       "dependencies": {
         "is-glob": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
-          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+          "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
           "requires": {
             "is-extglob": "^2.1.1"
           }
@@ -3623,7 +3628,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.1.tgz",
       "integrity": "sha1-9TsFJmqLGguTSz0IIebi3FkUriM=",
-      "dev": true,
       "requires": {
         "colors": "1.0.3"
       },
@@ -3631,8 +3635,7 @@
         "colors": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-          "dev": true
+          "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
         }
       }
     },
@@ -3905,12 +3908,11 @@
       "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
     },
     "compromise": {
-      "version": "11.13.1",
-      "resolved": "https://registry.npmjs.org/compromise/-/compromise-11.13.1.tgz",
-      "integrity": "sha512-u82ySLXPTcXNKZuqYmoUB5aglyVFpMzrJC0+k2WhA7i3x4KqkzzBLcAL7OpehbnuQEJWXfpV8LyIS0IXtZq9cA==",
+      "version": "11.13.2",
+      "resolved": "https://registry.npmjs.org/compromise/-/compromise-11.13.2.tgz",
+      "integrity": "sha512-E1zhtbVNapANcLVCktjm+GxZh+J3pE4epUXb6AgKRr1hYdM8AfUuV+sAS6M7Anuikq9q9HTMVttm1ignDLHt6A==",
       "requires": {
-        "efrt-unpack": "2.0.3",
-        "terser": "^3.14.1"
+        "efrt-unpack": "2.0.3"
       }
     },
     "concat-map": {
@@ -4034,14 +4036,13 @@
       }
     },
     "cosmiconfig": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.1.0.tgz",
-      "integrity": "sha512-kCNPvthka8gvLtzAxQXvWo4FxqRB+ftRZyPZNuab5ngvM9Y7yw7hbEysglptLgpkGX9nAOKTBVkHUAe8xtYR6Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
+      "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.9.0",
-        "lodash.get": "^4.4.2",
+        "js-yaml": "^3.13.0",
         "parse-json": "^4.0.0"
       }
     },
@@ -4095,7 +4096,6 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
       "integrity": "sha1-9NZnQQ6FDToxOn0tt7HlBbsDTMU=",
-      "dev": true,
       "requires": {
         "uniq": "^1.0.0"
       }
@@ -4134,8 +4134,7 @@
     "days": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/days/-/days-1.1.1.tgz",
-      "integrity": "sha512-vzeIwVsEIyA35GH4+mPd4hjVDNI87wYANyZFs0BHjBr5kIBH5zEl7LfD6Wr4SFZca4D3CU9IH1w4DuZLlXzKRw==",
-      "dev": true
+      "integrity": "sha512-vzeIwVsEIyA35GH4+mPd4hjVDNI87wYANyZFs0BHjBr5kIBH5zEl7LfD6Wr4SFZca4D3CU9IH1w4DuZLlXzKRw=="
     },
     "debug": {
       "version": "4.1.1",
@@ -4385,14 +4384,6 @@
         "kuler": "1.0.x"
       }
     },
-    "dicer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.3.0.tgz",
-      "integrity": "sha512-MdceRRWqltEG2dZqO769g27N/3PXfcKl04VhYnBlo2YhH7zPi88VebsjTKclaOyiuMaGU72hTfw3VkUitGcVCA==",
-      "requires": {
-        "streamsearch": "0.1.2"
-      }
-    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -4435,9 +4426,9 @@
       }
     },
     "dotenv": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
-      "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-7.0.0.tgz",
+      "integrity": "sha512-M3NhsLbV1i6HuGzBUH8vXrtxOk+tWmzWKDMbAVSUp3Zsjm7ywFeuwrUXhmhQyRK1q5B5GGy7hcXPbj3bnfZg2g=="
     },
     "duplexer2": {
       "version": "0.1.4",
@@ -4919,33 +4910,15 @@
       }
     },
     "espower-typescript": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/espower-typescript/-/espower-typescript-9.0.1.tgz",
-      "integrity": "sha512-WmEm8Hs0SX06izEdi4Qlu3GPOgshejXXA22OA5i+9oN0yC9pWLxlomyPkNkksAQl+ZV5dOGyTdC4gBAEfwqBww==",
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/espower-typescript/-/espower-typescript-9.0.2.tgz",
+      "integrity": "sha512-d8A0Sz67iOHhsMw3Qk1Jwr/G4ZNSm+o0anl+/rQ2SxfnvL3+Y6vSzPUnSgT++OR9zGlHFG9f7a3jmJO/UIr3HA==",
       "dev": true,
       "requires": {
         "espower-source": "^2.3.0",
         "minimatch": "^3.0.3",
         "source-map-support": "^0.5.9",
-        "ts-node": "^7.0.1"
-      },
-      "dependencies": {
-        "ts-node": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.0",
-            "buffer-from": "^1.1.0",
-            "diff": "^3.1.0",
-            "make-error": "^1.1.1",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "source-map-support": "^0.5.6",
-            "yn": "^2.0.0"
-          }
-        }
+        "ts-node": "^8.0.3"
       }
     },
     "esprima": {
@@ -5125,11 +5098,6 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-        },
         "statuses": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -5141,33 +5109,12 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/express-handlebars/-/express-handlebars-3.0.2.tgz",
       "integrity": "sha512-rPaSqR8xPnSqfvWvI8Mhtn7nifaMmySq6yhWkjH07Ks/nuDaRngJyf7eDN2I7PBkNVdZHf0Bz+1rY1yrZFdx8g==",
-      "dev": true,
       "requires": {
         "glob": "^7.1.3",
         "graceful-fs": "^4.1.2",
         "handlebars": "^4.0.13",
         "object.assign": "^4.1.0",
         "promise": "^8.0.2"
-      },
-      "dependencies": {
-        "handlebars": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.0.tgz",
-          "integrity": "sha512-l2jRuU1NAWK6AW5qqcTATWQJvNPEwkM7NEKSiv/gqOsoSQbVoWyqVEY5GS+XPQ88zLNmqASRpzfdm8d79hJS+w==",
-          "dev": true,
-          "requires": {
-            "async": "^2.5.0",
-            "optimist": "^0.6.1",
-            "source-map": "^0.6.1",
-            "uglify-js": "^3.1.4"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        }
       }
     },
     "express-session": {
@@ -5369,8 +5316,7 @@
     "file-url": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/file-url/-/file-url-2.0.2.tgz",
-      "integrity": "sha1-6VF4TXkJUSfTcTApqwY/QIGMoq4=",
-      "dev": true
+      "integrity": "sha1-6VF4TXkJUSfTcTApqwY/QIGMoq4="
     },
     "fill-range": {
       "version": "4.0.0",
@@ -5485,7 +5431,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/format-date/-/format-date-1.0.0.tgz",
       "integrity": "sha1-9hfwjiKpqWYCJEmC8iWmh/JcMH4=",
-      "dev": true,
       "requires": {
         "days": "^1.0.1",
         "left-pad": "^1.0.1",
@@ -5524,11 +5469,6 @@
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
       }
-    },
-    "fs-capacitor": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fs-capacitor/-/fs-capacitor-2.0.1.tgz",
-      "integrity": "sha512-kyV2oaG1/pu9NPosfGACmBym6okgzyg6hEtA5LSUq0dGpGLe278MVfMwVnSHDA/OBcTCHkPNqWL9eIwbPN6dDg=="
     },
     "fs-constants": {
       "version": "1.0.0",
@@ -6585,9 +6525,9 @@
       }
     },
     "globals": {
-      "version": "9.18.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw=="
     },
     "globule": {
       "version": "1.2.1",
@@ -6705,11 +6645,6 @@
           "requires": {
             "chalk": "^2.0.1"
           }
-        },
-        "prettier": {
-          "version": "1.16.3",
-          "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
-          "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw=="
         }
       }
     },
@@ -6778,14 +6713,6 @@
         "minimatch": "^3.0.4"
       }
     },
-    "graphql-extensions": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/graphql-extensions/-/graphql-extensions-0.4.3.tgz",
-      "integrity": "sha512-BEFZ7atqvzMInNTYEUAH5n091K4b5CE9+OZ25XfINc/9dKLR6Uft5DmwniDh/9v9dDCO5FhhIFBr0JmGtHDzeA==",
-      "requires": {
-        "@apollographql/apollo-tools": "^0.3.0"
-      }
-    },
     "graphql-import": {
       "version": "0.7.1",
       "resolved": "https://registry.npmjs.org/graphql-import/-/graphql-import-0.7.1.tgz",
@@ -6808,14 +6735,6 @@
       "integrity": "sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==",
       "requires": {
         "cross-fetch": "2.2.2"
-      }
-    },
-    "graphql-subscriptions": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/graphql-subscriptions/-/graphql-subscriptions-1.0.0.tgz",
-      "integrity": "sha512-+ytmryoHF1LVf58NKEaNPRUzYyXplm120ntxfPcgOBC7TnK7Tv/4VRHeh4FAR9iL+O1bqhZs4nkibxQ+OA5cDQ==",
-      "requires": {
-        "iterall": "^1.2.1"
       }
     },
     "graphql-tag": {
@@ -6876,17 +6795,6 @@
         "deprecated-decorator": "^0.1.6",
         "iterall": "^1.1.3",
         "uuid": "^3.1.0"
-      }
-    },
-    "graphql-upload": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/graphql-upload/-/graphql-upload-8.0.4.tgz",
-      "integrity": "sha512-jsTfVYXJ5mU6BXiiJ20CUCAcf41ICCQJ2ltwQFUuaFKiY4JhlG99uZZp5S3hbpQ/oA1kS7hz4pRtsnxPCa7Yfg==",
-      "requires": {
-        "busboy": "^0.3.0",
-        "fs-capacitor": "^2.0.0",
-        "http-errors": "^1.7.1",
-        "object-path": "^0.11.4"
       }
     },
     "growl": {
@@ -7147,9 +7055,9 @@
       "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ=="
     },
     "hoek": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.2.tgz",
-      "integrity": "sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q=="
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-6.1.3.tgz",
+      "integrity": "sha512-YXXAAhmF9zpQbC7LEcREFtXfGq5K1fmd+4PHkBq8NUqmzW3G+Dq10bI/i0KucLRwss3YYFQ0fSfoxBZYiGUqtQ=="
     },
     "hosted-git-info": {
       "version": "2.7.1",
@@ -7209,15 +7117,14 @@
       }
     },
     "http-errors": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
-      "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
-        "setprototypeof": "1.1.1",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.0"
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-proxy-agent": {
@@ -7407,8 +7314,7 @@
     "iota-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/iota-array/-/iota-array-1.0.0.tgz",
-      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc=",
-      "dev": true
+      "integrity": "sha1-ge9X/l0FgUzVjCSDYyqZwwoOgIc="
     },
     "ipaddr.js": {
       "version": "1.8.0",
@@ -7852,6 +7758,11 @@
         "nomnom": "1.5.2"
       }
     },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
     "joi": {
       "version": "14.3.1",
       "resolved": "https://registry.npmjs.org/joi/-/joi-14.3.1.tgz",
@@ -7865,13 +7776,12 @@
     "jpeg-js": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.1.2.tgz",
-      "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4=",
-      "dev": true
+      "integrity": "sha1-E1uZLAV1yYXPoPSUoyJ+0jhYPs4="
     },
     "js-tokens": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.13.0",
@@ -8029,8 +7939,7 @@
     "lazyness": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/lazyness/-/lazyness-1.1.1.tgz",
-      "integrity": "sha512-rYHC6l6LeRlJSt5jxpqN8z/49gZ0CqLi89HAGzJjHahCFlqEjFGFN9O15hmzSzUGFl7zN/vOWduv/+0af3r/kQ==",
-      "dev": true
+      "integrity": "sha512-rYHC6l6LeRlJSt5jxpqN8z/49gZ0CqLi89HAGzJjHahCFlqEjFGFN9O15hmzSzUGFl7zN/vOWduv/+0af3r/kQ=="
     },
     "lcid": {
       "version": "1.0.0",
@@ -8043,8 +7952,7 @@
     "left-pad": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA==",
-      "dev": true
+      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
     },
     "levn": {
       "version": "0.3.0",
@@ -8255,6 +8163,11 @@
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
+    "lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg="
+    },
     "lodash.template": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
@@ -8275,8 +8188,7 @@
     "lodash.toarray": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
+      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -8396,11 +8308,6 @@
         "request": "^2.87.0"
       }
     },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
-    },
     "longest-streak": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-2.0.2.tgz",
@@ -8446,9 +8353,9 @@
       "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
     },
     "macos-release": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.0.0.tgz",
-      "integrity": "sha512-iCM3ZGeqIzlrH7KxYK+fphlJpCCczyHXc+HhRVbEu9uNTCrzYJjvvtefzeKTCVHd5AP/aD/fzC80JZ4ZP+dQ/A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.2.0.tgz",
+      "integrity": "sha512-iV2IDxZaX8dIcM7fG6cI46uNmHUxHE4yN+Z8tKHAW1TBPMZDIKHf/3L+YnOuj/FK9il14UaVdHmiQ1tsi90ltA=="
     },
     "make-dir": {
       "version": "1.3.0",
@@ -8467,7 +8374,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
-      "dev": true,
       "requires": {
         "p-defer": "^1.0.0"
       }
@@ -8504,7 +8410,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-3.2.0.tgz",
       "integrity": "sha512-Yr1yVS0BbDG55vx7be1D0mdv+jGs9AW563o/Tt/7FTsId2J0yqhrTeXAqq/Q0DyyXltIn6CSxzesQuFqXgafjQ==",
-      "dev": true,
       "requires": {
         "ansi-escapes": "^3.1.0",
         "cardinal": "^2.1.1",
@@ -8783,8 +8688,7 @@
     "months": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/months/-/months-1.2.0.tgz",
-      "integrity": "sha512-zFM7hUpziSYGk2DNObYGWgHdRRxAOgjl8CC1Rbl50p/q0rGDsREfk0nbxxmSIquVi/lEAuUY8nwbwkZ8biNCOQ==",
-      "dev": true
+      "integrity": "sha512-zFM7hUpziSYGk2DNObYGWgHdRRxAOgjl8CC1Rbl50p/q0rGDsREfk0nbxxmSIquVi/lEAuUY8nwbwkZ8biNCOQ=="
     },
     "ms": {
       "version": "2.1.1",
@@ -8822,9 +8726,9 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw=="
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
+      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw=="
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -8853,7 +8757,6 @@
       "version": "1.0.18",
       "resolved": "https://registry.npmjs.org/ndarray/-/ndarray-1.0.18.tgz",
       "integrity": "sha1-tg06cyJOxVXQ+qeXEeUCRI/T95M=",
-      "dev": true,
       "requires": {
         "iota-array": "^1.0.0",
         "is-buffer": "^1.0.2"
@@ -8862,8 +8765,7 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         }
       }
     },
@@ -8871,7 +8773,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ndarray-pack/-/ndarray-pack-1.2.1.tgz",
       "integrity": "sha1-jK6+qqJNXs9w/4YCBjeXfajuWFo=",
-      "dev": true,
       "requires": {
         "cwise-compiler": "^1.1.2",
         "ndarray": "^1.0.13"
@@ -8914,8 +8815,7 @@
     "nextgen-events": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/nextgen-events/-/nextgen-events-1.1.0.tgz",
-      "integrity": "sha512-Emz5rh584fygInd3gtwP+xGyJhEnyxQa0/Xbmw8sbpXVGV/luqDnVPq1cQopYR7qg6KUlPfwWVhxrhZri1wDAw==",
-      "dev": true
+      "integrity": "sha512-Emz5rh584fygInd3gtwP+xGyJhEnyxQa0/Xbmw8sbpXVGV/luqDnVPq1cQopYR7qg6KUlPfwWVhxrhZri1wDAw=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -8938,8 +8838,7 @@
     "node-bitmap": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/node-bitmap/-/node-bitmap-0.0.1.tgz",
-      "integrity": "sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE=",
-      "dev": true
+      "integrity": "sha1-GA6scAPgxwdhjvMTaPYvhLKmkJE="
     },
     "node-cache": {
       "version": "4.2.0",
@@ -8954,7 +8853,6 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
       "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
-      "dev": true,
       "requires": {
         "lodash.toarray": "^4.4.0"
       }
@@ -12169,11 +12067,6 @@
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
       "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
     },
-    "object-path": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-      "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
-    },
     "object-visit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
@@ -12186,7 +12079,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
-      "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
         "function-bind": "^1.1.1",
@@ -12219,8 +12111,7 @@
     "omggif": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/omggif/-/omggif-1.0.9.tgz",
-      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8=",
-      "dev": true
+      "integrity": "sha1-3LcCTazVDFK00wPwSALJHAV8dl8="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -12238,8 +12129,7 @@
     "on-new-line": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/on-new-line/-/on-new-line-1.0.0.tgz",
-      "integrity": "sha1-hYW8KGbIwOGS5BCm1jvdFyIUiuc=",
-      "dev": true
+      "integrity": "sha1-hYW8KGbIwOGS5BCm1jvdFyIUiuc="
     },
     "once": {
       "version": "1.4.0",
@@ -12408,8 +12298,7 @@
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
-      "dev": true
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
     },
     "p-finally": {
       "version": "1.0.0",
@@ -12466,9 +12355,9 @@
       }
     },
     "p-try": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
-      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "pad": {
       "version": "0.0.4",
@@ -12705,8 +12594,7 @@
     "pngjs": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-2.3.1.tgz",
-      "integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8=",
-      "dev": true
+      "integrity": "sha1-EdHhK5y2TWPjDBQ6Mw9MH1Z9qF8="
     },
     "portfinder": {
       "version": "1.0.20",
@@ -12905,10 +12793,9 @@
       "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
     },
     "prettier": {
-      "version": "1.14.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.14.3.tgz",
-      "integrity": "sha512-qZDVnCrnpsRJJq5nSsiHCE3BYMED2OtsI+cmzIzF1QIfqm5ALf8tEJcO27zV1gKNKRPdhjO0dNWnrzssDQ1tFg==",
-      "dev": true
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
+      "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw=="
     },
     "prettify-xml": {
       "version": "1.2.0",
@@ -12931,10 +12818,9 @@
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
     },
     "promise": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.2.tgz",
-      "integrity": "sha512-EIyzM39FpVOMbqgzEHhxdrEhtOSDOtjMZQ0M6iVfCE+kWNgCkAyOdnuCWqfmflylftfadU6FkiMgHZA2kUzwRw==",
-      "dev": true,
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-8.0.3.tgz",
+      "integrity": "sha512-HeRDUL1RJiLhyA0/grn+PTShlBAcLuh/1BJGtrvjwbvRDCTLLMEz9rOGCV+R3vHY4MixIuoMEd9Yq/XvsTPcjw==",
       "requires": {
         "asap": "~2.0.6"
       }
@@ -12960,26 +12846,6 @@
       "requires": {
         "graceful-fs": "^4.1.2",
         "retry": "^0.10.0"
-      }
-    },
-    "protobufjs": {
-      "version": "6.8.8",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.8.8.tgz",
-      "integrity": "sha512-AAmHtD5pXgZfi7GMpllpO3q1Xw1OYldr+dMUlAnffGTAhqkg72WdmSY71uKBF/JuyiKs8psYbtKrhi0ASCD8qw==",
-      "requires": {
-        "@protobufjs/aspromise": "^1.1.2",
-        "@protobufjs/base64": "^1.1.2",
-        "@protobufjs/codegen": "^2.0.4",
-        "@protobufjs/eventemitter": "^1.1.0",
-        "@protobufjs/fetch": "^1.1.0",
-        "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.0",
-        "@protobufjs/path": "^1.1.2",
-        "@protobufjs/pool": "^1.1.0",
-        "@protobufjs/utf8": "^1.1.0",
-        "@types/long": "^4.0.0",
-        "@types/node": "^10.1.0",
-        "long": "^4.0.0"
       }
     },
     "protocols": {
@@ -13061,6 +12927,11 @@
         "strict-uri-encode": "^1.0.0"
       }
     },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
     "random-bytes": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
@@ -13092,24 +12963,6 @@
         "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
-        }
       }
     },
     "read-installed": {
@@ -13199,11 +13052,11 @@
       }
     },
     "recast": {
-      "version": "0.17.4",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.4.tgz",
-      "integrity": "sha512-94mbtFr2e4XoleJVCQQ138gK7xT2IScq25+thwEzNWd/hjOXQd6ejFiztgZZGVSByoV7/k3pLBXO3RK1BvJsIw==",
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.17.5.tgz",
+      "integrity": "sha512-K+DgfAMIyEjNKjaFSWgg9TTu7wFgU/4KTyw4E9vl6M5QPDuUYbyt49Yzb0EIDbZks+6lXk/UZ9eTuE4jlLyf2A==",
       "requires": {
-        "ast-types": "0.12.2",
+        "ast-types": "0.12.3",
         "esprima": "~4.0.0",
         "private": "^0.1.8",
         "source-map": "~0.6.1"
@@ -13522,9 +13375,9 @@
       }
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
     },
     "send": {
       "version": "0.16.2",
@@ -13554,26 +13407,10 @@
             "ms": "2.0.0"
           }
         },
-        "http-errors": {
-          "version": "1.6.3",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-          "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-          "requires": {
-            "depd": "~1.1.2",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.1.0",
-            "statuses": ">= 1.4.0 < 2"
-          }
-        },
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
-        },
-        "setprototypeof": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         },
         "statuses": {
           "version": "1.4.0",
@@ -13636,19 +13473,17 @@
     "setimmediate": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
+      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
     },
     "setprototypeof": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
-      "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "seventh": {
       "version": "0.7.18",
       "resolved": "https://registry.npmjs.org/seventh/-/seventh-0.7.18.tgz",
       "integrity": "sha512-fwO9/Ogh28KdAUz71fgJBn3NezuFWaiVLa2HW2/6TlAGsUzTUVPIuxQEGMKqPNerTJ+ZZDrFlPH98sdvBZpa1A==",
-      "dev": true,
       "requires": {
         "setimmediate": "^1.0.5"
       }
@@ -13719,7 +13554,6 @@
       "version": "0.93.42",
       "resolved": "https://registry.npmjs.org/simple-node-logger/-/simple-node-logger-0.93.42.tgz",
       "integrity": "sha512-3Kh0egP+iYr/TSDOdbLEMgyd9o6XsBMk3xk4Ds0/dwoclgDOqdOygusBixcr6ls0nG5xTpwgWiatWfZXjCiCLA==",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.10",
         "moment": "^2.20.1"
@@ -14163,11 +13997,6 @@
         }
       }
     },
-    "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
-    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
@@ -14176,14 +14005,12 @@
     "string-kit": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/string-kit/-/string-kit-0.9.1.tgz",
-      "integrity": "sha512-2iWkq43jbvG7WSqei4iVlpjmA7JWgqIC4lHgpwib0687B2d3qUOQQeaVDjqyG4Epuxx/0NY87zOqOyIjZVKxVA==",
-      "dev": true
+      "integrity": "sha512-2iWkq43jbvG7WSqei4iVlpjmA7JWgqIC4lHgpwib0687B2d3qUOQQeaVDjqyG4Epuxx/0NY87zOqOyIjZVKxVA=="
     },
     "string-templater": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-templater/-/string-templater-1.0.0.tgz",
-      "integrity": "sha1-IfPGIBZ5erWJmYN515VGnhjn5yQ=",
-      "dev": true
+      "integrity": "sha1-IfPGIBZ5erWJmYN515VGnhjn5yQ="
     },
     "string-width": {
       "version": "2.1.1",
@@ -14265,9 +14092,9 @@
       }
     },
     "strip-ansi": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.1.0.tgz",
-      "integrity": "sha512-TjxrkPONqO2Z8QDCpeE2j6n0M6EwxzyDgzEeGp+FbdvaJAt//ClYi6W5my+3ROlC/hZX2KACUwDfK49Ka5eDvg==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
       "requires": {
         "ansi-regex": "^4.1.0"
       }
@@ -14401,7 +14228,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
       "requires": {
         "execa": "^0.7.0"
       },
@@ -14410,7 +14236,6 @@
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
           "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-          "dev": true,
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -14421,7 +14246,6 @@
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-          "dev": true,
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -14436,7 +14260,6 @@
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
           "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
-          "dev": true,
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
@@ -14445,41 +14268,22 @@
         "yallist": {
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
-          "dev": true
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         }
       }
     },
     "terminal-kit": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.27.0.tgz",
-      "integrity": "sha512-vEKmPMaQKA/UadxjgJ99jxBGEiTcEzEG510cp2VXNgK63/h/zyS0hTQ4STPy87rsfh+n6PjEq4XbB/fdc9vgEQ==",
-      "dev": true,
+      "version": "1.27.2",
+      "resolved": "https://registry.npmjs.org/terminal-kit/-/terminal-kit-1.27.2.tgz",
+      "integrity": "sha512-aLfIz8ReP6Ifky5UxyRfP9dtnvtHR2rKa7nZuXeC+6uExQMpH7NFM/UL02ppiO9oNyGS4l3o8447y0ix6uRZeg==",
       "requires": {
         "@cronvel/get-pixels": "^3.3.1",
         "lazyness": "^1.1.1",
         "ndarray": "^1.0.18",
         "nextgen-events": "^1.1.0",
         "seventh": "^0.7.18",
-        "string-kit": "^0.9.0",
-        "tree-kit": "^0.6.0"
-      }
-    },
-    "terser": {
-      "version": "3.17.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-3.17.0.tgz",
-      "integrity": "sha512-/FQzzPJmCpjAH9Xvk2paiWrFq+5M6aVOf+2KRbwhByISDX/EujxsK+BAvrhb6H+2rtrLCHK9N01wO014vrIwVQ==",
-      "requires": {
-        "commander": "^2.19.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.10"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
+        "string-kit": "^0.9.1",
+        "tree-kit": "^0.6.1"
       }
     },
     "text-hex": {
@@ -14608,11 +14412,6 @@
         "repeat-string": "^1.6.1"
       }
     },
-    "toidentifier": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
-      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
-    },
     "toml": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/toml/-/toml-2.3.6.tgz",
@@ -14655,8 +14454,7 @@
     "tree-kit": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/tree-kit/-/tree-kit-0.6.1.tgz",
-      "integrity": "sha512-7mV4KbsLMuA6ths3J1wpVUj2PLmLdoNEGnP9fm3kxef4UXYC/A0rL5gKsqtkUaCMuRYUMORyioy8IpBWUBQ1Ig==",
-      "dev": true
+      "integrity": "sha512-7mV4KbsLMuA6ths3J1wpVUj2PLmLdoNEGnP9fm3kxef4UXYC/A0rL5gKsqtkUaCMuRYUMORyioy8IpBWUBQ1Ig=="
     },
     "treeify": {
       "version": "1.1.0",
@@ -14733,9 +14531,9 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
-      "version": "5.14.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.14.0.tgz",
-      "integrity": "sha512-IUla/ieHVnB8Le7LdQFRGlVJid2T/gaJe5VkjzRVSRR6pA2ODYrnfR1hmxi+5+au9l50jBwpbBL34txgv4NnTQ==",
+      "version": "5.15.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.15.0.tgz",
+      "integrity": "sha512-6bIEujKR21/3nyeoX2uBnE8s+tMXCQXhqMmaIPJpHmXJoBJPTLcI7/VHRtUwMhnLVdwLqqY3zmd8Dxqa5CVdJA==",
       "requires": {
         "babel-code-frame": "^6.22.0",
         "builtin-modules": "^1.1.1",
@@ -14743,7 +14541,7 @@
         "commander": "^2.12.1",
         "diff": "^3.2.0",
         "glob": "^7.1.1",
-        "js-yaml": "^3.7.0",
+        "js-yaml": "^3.13.0",
         "minimatch": "^3.0.4",
         "mkdirp": "^0.5.1",
         "resolve": "^1.3.2",
@@ -14842,26 +14640,20 @@
       "integrity": "sha1-bcJDPnjti+qOiHo6zeLzF4W9Yic="
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw=="
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz",
+      "integrity": "sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q=="
     },
     "uglify-js": {
-      "version": "3.4.9",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
-      "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.3.tgz",
+      "integrity": "sha512-rIQPT2UMDnk4jRX+w4WO84/pebU2jiLsjgIyrCktYgSvx28enOE3iYQMr+BD1rHiitWnDmpu0cY/LfIEpKcjcw==",
       "optional": true,
       "requires": {
-        "commander": "~2.17.1",
+        "commander": "~2.19.0",
         "source-map": "~0.6.1"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.17.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
-          "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "optional": true
-        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -14956,8 +14748,7 @@
     "uniq": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
-      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
-      "dev": true
+      "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8="
     },
     "unique-stream": {
       "version": "2.3.1",
@@ -15113,6 +14904,22 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
       "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+          "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+        }
+      }
     },
     "url-parse-lax": {
       "version": "3.0.0",
@@ -15308,9 +15115,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
-          "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -15364,9 +15171,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
-      "integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }
@@ -15388,6 +15195,20 @@
       "requires": {
         "sax": "^1.2.4"
       }
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmldoc": {
       "version": "1.1.2",
@@ -15489,9 +15310,9 @@
       }
     },
     "yarn": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.13.0.tgz",
-      "integrity": "sha512-Unfw2eefv8imt4ZMPhvFVP44WCz38huDxkHs+Yqrx4wBTK75Tr0mh3V4rh+2Nw5iQq0rcM/VafotCZo9qTb5DA=="
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/yarn/-/yarn-1.15.2.tgz",
+      "integrity": "sha512-DhqaGe2FcYKduO42d2hByXk7y8k2k42H3uzYdWBMTvcNcgWKx7xCkJWsVAQikXvaEQN2GyJNrz8CboqUmaBRrw=="
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@atomist/sdm-pack-issue": "1.2.0",
     "@atomist/sdm-pack-k8s": "^1.4.1",
     "@atomist/sdm-pack-node": "^1.0.4-master.20190328145741",
+    "@atomist/sdm-pack-s3": "0.1.0-master.20190319050251",
     "@atomist/sdm-pack-spring": "^1.1.1",
     "@atomist/slack-messages": "^1.1.0",
     "@types/app-root-path": "^1.2.4",

--- a/test/machine/webSupport.test.ts
+++ b/test/machine/webSupport.test.ts
@@ -1,0 +1,95 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as assert from "power-assert";
+import {
+    htmltestLogToReviewComments,
+} from "../../lib/machine/webSupport";
+
+/* tslint:disable:max-file-line-count */
+
+describe("machine/webSupport", () => {
+
+    describe("htmltestLogToReviewComments", () => {
+
+        it("should handle nothing", () => {
+            const rc = htmltestLogToReviewComments("");
+            assert(rc);
+            assert(rc.length === 0);
+        });
+
+        it("should parse logs into review comments", () => {
+            const rc = htmltestLogToReviewComments(`alt attribute missing --- index.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- about.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- pricing.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- get-started.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- github-permissions.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- terms.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- careers.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- resources.html --> /img/Atomist-Mark-Color.png
+target does not exist --- run-development-from-slack.html --> img/slack-logo-color.png
+target does not exist --- run-development-from-slack.html --> img/slack-own-the-issue%402x.png
+target does not exist --- run-development-from-slack.html --> img/slack-whos-committed%402x.png
+target does not exist --- run-development-from-slack.html --> img/slack-build-done-yet%402x.png
+target does not exist --- run-development-from-slack.html --> img/slack-one-click-pull-request%402x.png
+target does not exist --- run-development-from-slack.html --> img/slack-merge-with-ease%402x.png
+target does not exist --- run-development-from-slack.html --> img/slack-release-and-deploy%402x.png
+alt attribute missing --- run-development-from-slack.html --> /img/Atomist-Mark-Color.png
+target does not exist --- kubernetes.html --> img/kubernetes-webinar.png
+target does not exist --- kubernetes.html --> img/slack-deployment-approval.png
+target does not exist --- kubernetes.html --> img/slack-monitor-alert.png
+target does not exist --- kubernetes.html --> img/atomist-handles-config-details.png
+target does not exist --- kubernetes.html --> img/atomist-keep-your-deployments-safe.png
+alt attribute missing --- kubernetes.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- error-oauth.html --> /img/Atomist-Mark-Color.png
+target does not exist --- error-oauth.html --> js/min/scripts-min.jsv=2019.03.16
+alt attribute missing --- success-oauth.html --> /img/Atomist-Mark-Color.png
+target does not exist --- success-oauth.html --> js/min/scripts-min.jsv=2019.03.16
+target does not exist --- spring.html --> img/Atomist-Dashboard-Screenshot-New.png
+target does not exist --- spring.html --> img/icon-repo.png
+target does not exist --- spring.html --> img/icon-code-inspect.png
+target does not exist --- spring.html --> img/icon-terminal.png
+target does not exist --- spring.html --> img/icon-laptop-deploy.png
+target does not exist --- spring.html --> img/icon-cloud-terminal.png
+alt attribute missing --- spring.html --> /img/Atomist-Mark-Color.png
+target does not exist --- build-automations.html --> img/Atomist-Automate-Workflow.png
+alt attribute missing --- build-automations.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- success-github.html --> /img/Atomist-Mark-Color.png
+target does not exist --- success-github.html --> js/min/scripts-min.jsv=2019.03.16
+alt attribute missing --- success.html --> /img/Atomist-Mark-Color.png
+target does not exist --- success.html --> js/min/scripts-min.jsv=2019.03.16
+alt attribute missing --- success-slack.html --> /img/Atomist-Mark-Color.png
+target does not exist --- success-slack.html --> js/min/scripts-min.jsv=2019.03.16
+alt attribute missing --- success-github-user.html --> /img/Atomist-Mark-Color.png
+target does not exist --- success-github-user.html --> js/min/scripts-min.jsv=2019.03.16
+alt attribute missing --- developer.html --> /img/Atomist-Mark-Color.png
+alt attribute missing --- privacy.html --> /img/Atomist-Mark-Color.png
+`);
+            assert(rc);
+            assert(rc.length === 45);
+            assert(rc.every(c => c.category === "htmltest"));
+            assert(rc.filter(c => c.subcategory === "alt attribute missing").length === 20);
+            assert(rc.filter(c => c.subcategory === "target does not exist").length === 25);
+            assert(rc.filter(c => c.subcategory === "alt attribute missing").every(c => c.severity === "warn"));
+            assert(rc.filter(c => c.subcategory === "target does not exist").every(c => c.severity === "error"));
+            assert(rc.filter(c => c.sourceLocation.path === "kubernetes.html").length === 6);
+            assert(rc.filter(c => c.sourceLocation.path === "kubernetes.html").filter(c => c.subcategory === "alt attribute missing").length === 1);
+            assert(rc.filter(c => c.sourceLocation.path === "kubernetes.html").filter(c => c.subcategory === "target does not exist").length === 5);
+        });
+
+    });
+
+});


### PR DESCRIPTION
Elevate file versioner to a first class thing.

Add support for building jekyll and npm sites.

Add htmltest code inspection for jekyll sites.

Add support for publishing to S3 via sdm-pack-s3.

Start putting goals into machine function so we are not using package
globals.

Closes #113 

These changes seem like a bit of a mess but I'm not sure how to better organize things.
