### PR TITLE
Clean up goals for web repos and others

### DIFF
--- a/lib/machine/machine.ts
+++ b/lib/machine/machine.ts
@@ -19,7 +19,6 @@ import {
     guid,
 } from "@atomist/automation-client";
 import {
-    allSatisfied,
     anySatisfied,
     gitHubTeamVoter,
     GoalApprovalRequestVote,
@@ -133,7 +132,7 @@ export function machine(configuration: SoftwareDeliveryMachineConfiguration): So
         region: "us-east-1",
         filesToPublish: ["images/**/*"],
         pathTranslation: filepath => filepath.replace("images/", ""),
-        pathToIndex: "images/index.html",
+        pathToIndex: "images/",
     });
     const S3ImagesGoals = goals("Image Publish").plan(publishS3Images);
 
@@ -163,8 +162,7 @@ export function machine(configuration: SoftwareDeliveryMachineConfiguration): So
         region: "us-east-1",
         filesToPublish: ["public/**/*"],
         pathTranslation: filepath => filepath.replace("public/", ""),
-        pathToIndex: "public/index.html",
-        approvalRequired: true,
+        pathToIndex: "public/",
     }).withProjectListener(WebNpmBuildAfterCheckout);
     const publishWebAppToProduction = new PublishToS3({
         environment: ProductionEnvironment,
@@ -173,15 +171,14 @@ export function machine(configuration: SoftwareDeliveryMachineConfiguration): So
         region: "us-east-1",
         filesToPublish: ["public/**/*"],
         pathTranslation: filepath => filepath.replace("public/", ""),
-        pathToIndex: "public/index.html",
+        pathToIndex: "public/",
+        preApprovalRequired: true,
     }).withProjectListener(WebNpmBuildAfterCheckout);
     const WebAppGoals = goals("Web App Build with Release")
         .plan(WebBuildGoals)
         .plan(publishWebAppToStaging).after(buildWeb)
         .plan(publishWebAppToProduction).after(publishWebAppToStaging)
-        .plan(releaseVersion).after(publishWebAppToProduction)
-        .plan(releaseChangelog).after(releaseVersion)
-        .plan(releaseTag).after(releaseChangelog);
+        .plan(releaseTag, releaseVersion).after(publishWebAppToProduction);
 
     const publishWebSiteToStaging = new PublishToS3({
         environment: StagingEnvironment,
@@ -190,8 +187,7 @@ export function machine(configuration: SoftwareDeliveryMachineConfiguration): So
         region: "us-east-1",
         filesToPublish: ["_site/**/*"],
         pathTranslation: filepath => filepath.replace("_site/", ""),
-        pathToIndex: "_site/index.html",
-        approvalRequired: true,
+        pathToIndex: "_site/",
     }).withProjectListener(JekyllBuildAfterCheckout);
     const publishWebSiteToProduction = new PublishToS3({
         environment: ProductionEnvironment,
@@ -200,15 +196,15 @@ export function machine(configuration: SoftwareDeliveryMachineConfiguration): So
         region: "us-east-1",
         filesToPublish: ["_site/**/*"],
         pathTranslation: filepath => filepath.replace("_site/", ""),
-        pathToIndex: "_site/index.html",
+        pathToIndex: "_site/",
+        preApprovalRequired: true,
     }).withProjectListener(JekyllBuildAfterCheckout);
     const WebSiteGoals = goals("Web Site Build with Release")
         .plan(WebBuildGoals)
         .plan(publishWebSiteToStaging, autoCodeInspection).after(buildWeb)
         .plan(publishWebSiteToProduction).after(publishWebSiteToStaging)
-        .plan(releaseVersion).after(publishWebSiteToProduction)
-        .plan(releaseChangelog).after(releaseVersion)
-        .plan(releaseTag).after(releaseChangelog);
+        .plan(releaseTag, releaseVersion).after(publishWebSiteToProduction)
+        .plan(releaseChangelog).after(releaseVersion);
 
     const sdm = createSoftwareDeliveryMachine({
         name: "Atomist Software Delivery Machine",
@@ -218,11 +214,11 @@ export function machine(configuration: SoftwareDeliveryMachineConfiguration): So
         whenPushSatisfies(isOrgNamed("atomist-playground"))
             .setGoals(goals("No Goals")),
 
-        whenPushSatisfies(allSatisfied(isOrgNamed("atomist-seeds"), not(nameMatches(/sdm/))))
+        whenPushSatisfies(isOrgNamed("atomist-seeds"), not(nameMatches(/sdm/)))
             .itMeans("Non-Atomist seed")
             .setGoals(goals("No Goals")),
 
-        whenPushSatisfies(allSatisfied(isOrgNamed("sdd-manifesto"), isNamed("manifesto", "manifesto-app")))
+        whenPushSatisfies(isOrgNamed("sdd-manifesto"), isNamed("manifesto", "manifesto-app"))
             .itMeans("Manifesto repository")
             .setGoals(goals("No Goals")),
 
@@ -234,24 +230,25 @@ export function machine(configuration: SoftwareDeliveryMachineConfiguration): So
             .itMeans("Node repository in local mode")
             .setGoals(LocalGoals),
 
-        whenPushSatisfies(allSatisfied(isOrgNamed("atomisthq"), isNamed("s3-images")))
-            .itMeans("Images Site")
+        whenPushSatisfies(isOrgNamed("atomisthq"), isNamed("s3-images"), ToDefaultBranch)
+            .itMeans("Images Site Deploy")
             .setGoals(S3ImagesGoals),
-
-        whenPushSatisfies(allSatisfied(isOrgNamed("atomisthq"), isNamed("web-app")))
-            .itMeans("Web App")
+        whenPushSatisfies(isOrgNamed("atomisthq"), isNamed("web-app"), ToDefaultBranch)
+            .itMeans("Web App Deploy")
             .setGoals(WebAppGoals),
-
-        whenPushSatisfies(allSatisfied(isOrgNamed("atomisthq"), isNamed("web-site")))
-            .itMeans("Web Site")
+        whenPushSatisfies(isOrgNamed("atomisthq"), isNamed("web-site"), ToDefaultBranch)
+            .itMeans("Web Site Deploy")
             .setGoals(WebSiteGoals),
+        whenPushSatisfies(isOrgNamed("atomisthq"), isNamed("web-app", "web-app"))
+            .itMeans("Web Build")
+            .setGoals(WebBuildGoals),
 
         whenPushSatisfies(not(isSdmEnabled(configuration.name)), isTeam(AtomistHQWorkspace))
             .itMeans("Disabled repository in atomisthq workspace")
             .setGoals(goals("No Goals")),
 
         // Node
-        whenPushSatisfies(allSatisfied(IsNode, not(IsMaven)), not(MaterialChangeToNodeRepo))
+        whenPushSatisfies(IsNode, not(IsMaven), not(MaterialChangeToNodeRepo))
             .itMeans("No Material Change")
             .setGoals(FixGoals),
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -601,9 +601,9 @@
       }
     },
     "@atomist/sdm-pack-issue": {
-      "version": "1.2.1-master.20190404122828",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-issue/-/sdm-pack-issue-1.2.1-master.20190404122828.tgz",
-      "integrity": "sha512-mfmONVqXdjWuEuVHDR8vujk2lfOjTUUAZEqoXBpD4rIyqJ4mIcqm3PCnYXh9ft9X92M+HSaMRuqdEHb9f1SRaQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-issue/-/sdm-pack-issue-1.2.1.tgz",
+      "integrity": "sha512-ToL8OWNsH+18B9qyt14EywdlC4WTiWiqljcK08Y5TsItzYwCG6AgY9QGCjICged1HkBXWusdlHr2o1n4P4wlaw==",
       "requires": {
         "@octokit/rest": "^15.16.1",
         "axios": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@atomist/sdm-pack-changelog": "^1.0.2",
     "@atomist/sdm-pack-docker": "^1.1.0",
     "@atomist/sdm-pack-fingerprints": "^2.0.2",
-    "@atomist/sdm-pack-issue": "1.2.1-master.20190404122828",
+    "@atomist/sdm-pack-issue": "^1.2.1",
     "@atomist/sdm-pack-k8s": "^1.4.1",
     "@atomist/sdm-pack-node": "^1.0.4-master.20190328145741",
     "@atomist/sdm-pack-s3": "0.1.0-master.20190319050251",


### PR DESCRIPTION
Remove use of allSatisfied, it is redundant since whenPushSatisfies
ensures all of its guards are satisfied.

Only deploy sites when commit is on default branch.

Remove release changelog goal from web-app.

Update sdm-pack-issue.