### PR TITLE
Add Go support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && apt-get install -y \
         openjdk-8-jdk-headless maven \
         bundler \
         zlib1g-dev \
+        golang-go \
     && rm -rf /var/lib/apt/lists/*
 
 ENV LEIN_ROOT true

--- a/lib/machine/goSupport.ts
+++ b/lib/machine/goSupport.ts
@@ -1,0 +1,298 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitProject,
+    Project,
+    RemoteRepoRef,
+} from "@atomist/automation-client";
+import {
+    allSatisfied,
+    ExecuteGoalResult,
+    GoalInvocation,
+    GoalProjectListenerEvent,
+    GoalProjectListenerRegistration,
+    hasFile,
+    LogSuppressor,
+    ProgressLog,
+    SoftwareDeliveryMachine,
+    spawnLog,
+    SpawnLogOptions,
+    SpawnLogResult,
+} from "@atomist/sdm";
+import { ProjectVersioner } from "@atomist/sdm-core";
+import { Builder } from "@atomist/sdm-pack-build";
+import {
+    DockerOptions,
+} from "@atomist/sdm-pack-docker";
+import * as fs from "fs-extra";
+import * as path from "path";
+import * as semver from "semver";
+import {
+    build,
+    dockerBuild,
+    noOpGoalExecutor,
+    publish,
+    release,
+    releaseDocs,
+    releaseVersion,
+    version,
+} from "./goals";
+import {
+    addBranchPreRelease,
+    executeReleaseVersion,
+} from "./release";
+
+/**
+ * Push test for Go projects built with make.
+ */
+export const IsGoMake = allSatisfied(hasFile("main.go"), hasFile("Makefile"));
+
+/**
+ * Push test for Go projects built with make with Dockerfile.
+ */
+export const IsGoMakeDocker = allSatisfied(IsGoMake, hasFile("docker/Dockerfile"));
+
+/**
+ * Add Go support and implementations of SDM goals.
+ *
+ * @param sdm Software Delivery machine to modify
+ * @return modified software delivery machine
+ */
+export function addGoSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMachine {
+
+    version.with({
+        name: "go-versioner",
+        logInterpreter: LogSuppressor,
+        pushTest: IsGoMake,
+        versioner: GoVersioner,
+    });
+
+    build.with({
+        name: "go-make-build",
+        builder: GoBuilder,
+        pushTest: IsGoMake,
+    })
+        .withProjectListener(GoPathHack);
+
+    publish.with({
+        name: "go-publish",
+        goalExecutor: noOpGoalExecutor,
+        pushTest: IsGoMake,
+    });
+
+    dockerBuild.with({
+        name: "go-docker-build",
+        options: {
+            ...sdm.configuration.sdm.docker.hub as DockerOptions,
+            push: true,
+            builder: "docker",
+            builderPath: "docker",
+            dockerfileFinder: async () => "docker/Dockerfile",
+        },
+        logInterpreter: LogSuppressor,
+        pushTest: IsGoMakeDocker,
+    })
+        .withProjectListener(GoDockerBuild);
+
+    release.with({
+        name: "go-release",
+        goalExecutor: noOpGoalExecutor,
+        pushTest: IsGoMake,
+    });
+
+    releaseVersion.with({
+        name: "go-release-version",
+        goalExecutor: executeReleaseVersion(goProjectIdentifier, goIncrementPatch),
+        logInterpreter: LogSuppressor,
+        pushTest: IsGoMake,
+    });
+
+    releaseDocs.with({
+        name: "go-release",
+        goalExecutor: noOpGoalExecutor,
+        pushTest: IsGoMake,
+    });
+
+    return sdm;
+}
+
+const goExtractVersionRegExp = /^[\S\s]*\bversion\s*=\s*"(\d+\.\d+\.\d+)"[\S\s]*$/;
+const goSetVersionRegExp = /^(\s*version\s*=\s*)"(\d+\.\d+\.\d+)"\s*$/m;
+
+const GoVersioner: ProjectVersioner = async (e, p, l) => {
+    const baseVersion = (await goProjectIdentifier(p)).version;
+    l.write(`Using base version '${baseVersion}'`);
+    const prereleaseVersion = addBranchPreRelease(baseVersion, e);
+    l.write(`Calculated pre-release version '${prereleaseVersion}'`);
+    return prereleaseVersion;
+};
+
+/**
+ * Extract project information from Go project.
+ */
+export const goProjectIdentifier = async (p: Project) => {
+    let v: string;
+    const versionFile = await p.getFile("cmd/version.go");
+    if (versionFile) {
+        v = (await versionFile.getContent()).replace(goExtractVersionRegExp, "$1");
+    } else {
+        v = "0.0.0";
+    }
+    return {
+        id: p.id as RemoteRepoRef,
+        name: p.name,
+        version: v,
+    };
+};
+
+interface ProjectGoPath {
+    goPath: string;
+    goProjectDir: string;
+}
+
+function projectGoPath(project: GitProject): ProjectGoPath {
+    const goPath = path.join(project.baseDir, ".gosdm");
+    const goProjectDir = path.join(goPath, "src", "github.com", "atomist", project.name);
+    return { goPath, goProjectDir };
+}
+
+/**
+ * Hack a GOPATH to work with the way the SDM checks projects out.
+ */
+export async function goPathHack(project: GitProject, goalInvocation: GoalInvocation): Promise<ExecuteGoalResult> {
+    const log = goalInvocation.progressLog;
+    const pgp = projectGoPath(project);
+    if (fs.existsSync(pgp.goProjectDir)) {
+        const msg = `Go project directory already exists: ${pgp.goProjectDir}`;
+        log.write(msg);
+        return { code: 0, message: msg };
+    }
+    try {
+        const projectCopyPath = project.baseDir + ".gosdm.tmp";
+        await fs.ensureDir(projectCopyPath);
+        await fs.copy(project.baseDir, projectCopyPath);
+        await fs.ensureDir(pgp.goProjectDir);
+        await fs.move(projectCopyPath, pgp.goProjectDir, { overwrite: true });
+    } catch (e) {
+        const msg = `Failed to create GOPATH directory tree for ${project.name}: ${e.message}`;
+        log.write(msg);
+        return { code: 1, message: msg };
+    }
+    const message = `Created GOPATH tree for ${project.name}: ${pgp.goProjectDir}`;
+    log.write(message);
+    return { code: 0, message };
+}
+
+export const GoPathHack: GoalProjectListenerRegistration = {
+    name: "go path hack",
+    events: [GoalProjectListenerEvent.before],
+    listener: goPathHack,
+    pushTest: IsGoMake,
+};
+
+/**
+ * Generic make executor for Go projects.  GoPathHack should be
+ * executed before this.
+ */
+async function goMake(p: GitProject, log: ProgressLog, args: string[] = []): Promise<SpawnLogResult> {
+    const pgp = projectGoPath(p);
+    const makeOptions: SpawnLogOptions = {
+        cwd: pgp.goProjectDir,
+        env: { ...process.env, GOPATH: pgp.goPath },
+        log,
+    };
+    log.write(`Running 'make' for ${p.name} in '${makeOptions.cwd}' with GOPATH='${makeOptions.env.GOPATH}'`);
+    const makeResult = await spawnLog("make", args, makeOptions);
+    if (makeResult.code) {
+        if (makeResult.error) {
+            log.write(`Make errored for ${p.name}: ${makeResult.error.message}`);
+        } else {
+            log.write(`Make failed for ${p.name}: ${makeResult.code}`);
+        }
+    } else {
+        log.write(`Successful 'make' invocation for ${p.name} in '${pgp.goProjectDir}' with GOPATH='${pgp.goPath}'`);
+    }
+    return makeResult;
+}
+
+/**
+ * Builder for Go projects that use make.  GoPathHack should be
+ * executed before this.
+ */
+const GoBuilder: Builder = (goalInvocation: GoalInvocation, buildNo: string) => {
+    const { configuration, credentials, id, progressLog } = goalInvocation;
+
+    return configuration.sdm.projectLoader.doWithProject({ credentials, id, readOnly: true, cloneOptions: { detachHead: true } },
+        async p => {
+            const appInfo = await goProjectIdentifier(p);
+            const buildResult = await goMake(p, progressLog);
+            return { appInfo, buildResult, deploymentUnitFile: undefined };
+        },
+    );
+};
+
+/**
+ * Build amd64/linux binary for Docker.
+ */
+const GoDockerBuild: GoalProjectListenerRegistration = {
+    name: "go-make-docker",
+    events: [GoalProjectListenerEvent.before],
+    listener: (p, gi) => spawnLog("make", ["docker-target"], { cwd: p.baseDir, log: gi.progressLog }),
+    pushTest: IsGoMakeDocker,
+};
+
+/**
+ * Command for incrementing the version patch value in
+ * `cmd/version.go` and `Makefile`.
+ */
+export async function goIncrementPatch(p: Project, log: ProgressLog): Promise<ExecuteGoalResult> {
+    const vPath = "cmd/version.go";
+    const vFile = await p.getFile(vPath);
+    if (!vFile) {
+        const msg = `Project does not have '${vPath}' file`;
+        log.write(msg);
+        return { code: 1, message: msg };
+    }
+    const vContent = await vFile.getContent();
+    const currentVersion = vContent.replace(goExtractVersionRegExp, "$1");
+    if (!currentVersion) {
+        const msg = `Failed to extract version from '${vPath}' file`;
+        log.write(msg);
+        return { code: 1, message: msg };
+    }
+    const newVersion = semver.inc(currentVersion, "patch");
+    if (!newVersion || newVersion === currentVersion) {
+        const msg = `Failed to increment patch in version '${currentVersion}' from '${vPath}' file`;
+        log.write(msg);
+        return { code: 1, message: msg };
+    }
+    log.write(`Incremented version: ${currentVersion} => ${newVersion}`);
+    await vFile.setContent(vContent.replace(goSetVersionRegExp, `$1"${newVersion}"`));
+    log.write(`Incremented patch level in '${vPath}' file`);
+    const makefilePath = "Makefile";
+    const makefileFile = await p.getFile(makefilePath);
+    if (!makefileFile) {
+        const msg = `Project does not have '${makefilePath}' file`;
+        log.write(msg);
+        return { code: 1, message: msg };
+    }
+    await makefileFile.setContent((await makefileFile.getContent()).replace(/^DOCKER_VERSION\s*=.*/m, `DOCKER_VERSION = ${newVersion}`));
+    log.write(`Incremented patch level in '${makefilePath}' file`);
+    const message = `Incremented patch level: ${currentVersion} => ${newVersion}`;
+    log.write(message);
+    return { code: 0, message };
+}

--- a/lib/machine/goals.ts
+++ b/lib/machine/goals.ts
@@ -75,13 +75,13 @@ export const publishWithApproval = new GoalWithFulfillment({
     approvalRequired: true,
 }, build, dockerBuild);
 
-export const releaseNpm = new GoalWithFulfillment({
-    uniqueName: "release-npm",
+export const release = new GoalWithFulfillment({
+    uniqueName: "release",
     environment: ProductionEnvironment,
-    displayName: "release NPM package",
-    workingDescription: "Releasing NPM package",
-    completedDescription: "Released NPM package",
-    failedDescription: "Release NPM package failure",
+    displayName: "release",
+    workingDescription: "Releasing",
+    completedDescription: "Released",
+    failedDescription: "Release failed",
     isolated: true,
 });
 
@@ -160,13 +160,13 @@ export const BuildReleaseGoals = goals("Build with Release")
     .plan(LocalGoals)
     .plan(tag).after(build)
     .plan(publishWithApproval).after(build)
-    .plan(releaseNpm, releaseDocs, releaseVersion).after(publishWithApproval, autoCodeInspection)
+    .plan(release, releaseDocs, releaseVersion).after(publishWithApproval, autoCodeInspection)
     .plan(releaseChangelog).after(releaseVersion)
-    .plan(releaseTag).after(releaseNpm);
+    .plan(releaseTag).after(release);
 
 export const BuildReleaseAndHomebrewGoals = goals("Build with Release, Homebrew")
     .plan(BuildReleaseGoals)
-    .plan(releaseHomebrew).after(releaseNpm);
+    .plan(releaseHomebrew).after(release);
 
 // Build including docker build
 export const DockerGoals = goals("Docker Build")
@@ -193,9 +193,9 @@ export const DockerReleaseGoals = goals("Docker Build with Release")
     .plan(dockerBuild).after(build)
     .plan(tag).after(dockerBuild)
     .plan(publishWithApproval).after(build, dockerBuild)
-    .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(publishWithApproval, autoCodeInspection)
+    .plan(release, releaseDocker, releaseDocs, releaseVersion).after(publishWithApproval, autoCodeInspection)
     .plan(releaseChangelog).after(releaseVersion)
-    .plan(releaseTag, releaseHomebrew).after(releaseNpm, releaseDocker);
+    .plan(releaseTag, releaseHomebrew).after(release, releaseDocker);
 
 export const SimpleDockerReleaseGoals = goals("Simple Docker Build with Release")
     .plan(version)
@@ -210,17 +210,17 @@ export const KubernetesDeployGoals = goals("Deploy")
     .plan(DockerGoals)
     .plan(stagingDeploy).after(dockerBuild)
     .plan(productionDeploy).after(stagingDeploy, autoCodeInspection)
-    .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(productionDeploy)
+    .plan(release, releaseDocker, releaseDocs, releaseVersion).after(productionDeploy)
     .plan(releaseChangelog).after(releaseVersion)
-    .plan(releaseTag).after(releaseNpm, releaseDocker);
+    .plan(releaseTag).after(release, releaseDocker);
 
 // Docker build and testing and production kubernetes deploy
 export const SimplifiedKubernetesDeployGoals = goals("Simplified Deploy")
     .plan(DockerGoals)
     .plan(productionDeployWithApproval).after(dockerBuild, autoCodeInspection)
-    .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(productionDeployWithApproval)
+    .plan(release, releaseDocker, releaseDocs, releaseVersion).after(productionDeployWithApproval)
     .plan(releaseChangelog).after(releaseVersion)
-    .plan(releaseTag).after(releaseNpm, releaseDocker);
+    .plan(releaseTag).after(release, releaseDocker);
 
 // Docker build and testing and demo kubernetes deploy, no release
 export const DemoKubernetesDeployGoals = goals("Demo Deploy")
@@ -232,15 +232,17 @@ export const GlobalKubernetesDeployGoals = goals("Global Deploy")
     .plan(DockerGoals)
     .plan(globalStagingDeploy).after(dockerBuild)
     .plan(globalProductionDeploy).after(globalStagingDeploy, autoCodeInspection)
-    .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(globalProductionDeploy)
+    .plan(release, releaseDocker, releaseDocs, releaseVersion).after(globalProductionDeploy)
     .plan(releaseChangelog).after(releaseVersion)
-    .plan(releaseTag).after(releaseNpm, releaseDocker);
+    .plan(releaseTag).after(release, releaseDocker);
 
 // Docker build and testing and multiple production kubernetes deploys
 export const MultiKubernetesDeployGoals = goals("Multiple Deploy")
     .plan(DockerGoals)
     .plan(productionDeployWithApproval).after(dockerBuild, autoCodeInspection)
     .plan(demoProductionDeploy, globalProductionDeploy).after(productionDeployWithApproval)
-    .plan(releaseNpm, releaseDocker, releaseDocs, releaseVersion).after(productionDeployWithApproval)
+    .plan(release, releaseDocker, releaseDocs, releaseVersion).after(productionDeployWithApproval)
     .plan(releaseChangelog).after(releaseVersion)
-    .plan(releaseTag).after(releaseNpm, releaseDocker);
+    .plan(releaseTag).after(release, releaseDocker);
+
+export const noOpGoalExecutor = () => Promise.resolve({ code: 0, message: "Nothing to do" });

--- a/lib/machine/homebrewSupport.ts
+++ b/lib/machine/homebrewSupport.ts
@@ -46,8 +46,8 @@ import * as crypto from "crypto";
 import * as fs from "fs-extra";
 import * as path from "path";
 import { releaseHomebrew } from "./goals";
+import { downloadNpmPackage } from "./nodeSupport";
 import {
-    downloadNpmPackage,
     releaseOrPreRelease,
     rwlcVersion,
 } from "./release";

--- a/lib/machine/k8sSupport.ts
+++ b/lib/machine/k8sSupport.ts
@@ -29,6 +29,7 @@ import {
     KubernetesApplication,
     KubernetesDeploy,
 } from "@atomist/sdm-pack-k8s";
+import { IsAtomistAutomationClient } from "@atomist/sdm-pack-node";
 import { IsMaven } from "@atomist/sdm-pack-spring";
 import * as stringify from "json-stringify-safe";
 import * as _ from "lodash";
@@ -59,7 +60,12 @@ export async function kubernetesApplicationData(
 
     const name = goalEvent.repo.name;
     const ns = namespaceFromGoal(goalEvent);
-    const port = (await IsMaven.predicate(p)) ? 8080 : 2866;
+    let port: number;
+    if (await IsMaven.predicate(p)) {
+        port = 8080;
+    } else if (await IsAtomistAutomationClient.predicate(p)) {
+        port = 2866;
+    }
     let replicas = 1;
     if (ns === "production") {
         replicas = 3;
@@ -94,6 +100,8 @@ function namespaceFromGoal(goalEvent: SdmGoalEvent): string {
         }
     } else if (/-sdm$/.test(name) && name !== "sample-sdm" && name !== "spring-sdm") {
         return "sdm";
+    } else if (name === "k8vent") {
+        return "k8vent";
     } else if (goalEvent.environment === StagingEnvironment.replace(/\/$/, "")) {
         return "testing";
     } else if (goalEvent.environment === ProductionEnvironment.replace(/\/$/, "")) {

--- a/lib/machine/nodeSupport.ts
+++ b/lib/machine/nodeSupport.ts
@@ -14,14 +14,40 @@
  * limitations under the License.
  */
 
+/* tslint:disable:max-file-line-count */
+
+import {
+    configurationValue,
+    GitCommandGitProject,
+    GitHubRepoRef,
+    GitProject,
+    guid,
+    logger,
+    NodeFsLocalProject,
+    RemoteRepoRef,
+    Success,
+    TokenCredentials,
+} from "@atomist/automation-client";
 import {
     allSatisfied,
     ApproveGoalIfErrorComments,
+    ExecuteGoal,
+    ExecuteGoalResult,
+    GoalInvocation,
     LogSuppressor,
     not,
+    PrepareForGoalExecution,
+    ProgressLog,
+    projectConfigurationValue,
+    SdmGoalState,
     SoftwareDeliveryMachine,
+    spawnLog,
 } from "@atomist/sdm";
-import { tagRepo } from "@atomist/sdm-core";
+import {
+    github,
+    ProjectIdentifier,
+    tagRepo,
+} from "@atomist/sdm-core";
 import {
     DockerOptions,
     HasDockerfile,
@@ -29,6 +55,7 @@ import {
 import { singleIssuePerCategoryManaging } from "@atomist/sdm-pack-issue";
 import {
     AddThirdPartyLicenseAutofix,
+    DevelopmentEnvOptions,
     executePublish,
     IsNode,
     nodeBuilder,
@@ -48,6 +75,8 @@ import {
     npmInstallProjectListener,
 } from "@atomist/sdm-pack-node/lib/build/npmBuilder";
 import { IsMaven } from "@atomist/sdm-pack-spring";
+import * as fs from "fs-extra";
+import * as path from "path";
 import { AddAtomistTypeScriptHeader } from "../autofix/addAtomistHeader";
 import { TypeScriptImports } from "../autofix/imports/importsFix";
 import {
@@ -56,6 +85,12 @@ import {
 } from "../autofix/test/testNamingFix";
 import { UpdateSupportFilesTransform } from "../autofix/updateSupportFiles";
 import { deleteDistTagOnBranchDeletion } from "../event/deleteDistTagOnBranchDeletion";
+import {
+    executeLoggers,
+    gitExecuteLogger,
+    spawnExecuteLogger,
+    SpawnWatchCommand,
+} from "../support/executeLogger";
 import {
     isNamed,
     isOrgNamed,
@@ -73,31 +108,20 @@ import {
     autoCodeInspection,
     autofix,
     build,
-    demoProductionDeploy,
     dockerBuild,
-    globalProductionDeploy,
-    globalStagingDeploy,
-    productionDeploy,
-    productionDeployWithApproval,
     publish,
     publishWithApproval,
+    release,
     releaseDocs,
-    releaseNpm,
     releaseVersion,
-    stagingDeploy,
     version,
 } from "./goals";
 import {
-    kubernetesDeployRegistrationDemo,
-    kubernetesDeployRegistrationGlobal,
-    kubernetesDeployRegistrationProd,
-} from "./k8sSupport";
-import {
-    DocsReleasePreparations,
-    executeReleaseDocs,
-    executeReleaseNpm,
     executeReleaseVersion,
-    NpmReleasePreparations,
+    isNextVersion,
+    ProjectRegistryInfo,
+    releaseOrPreRelease,
+    rwlcVersion,
 } from "./release";
 
 const NodeDefaultOptions = {
@@ -217,14 +241,7 @@ export function addNodeSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMa
         .withProjectListener(NpmVersionProjectListener)
         .withProjectListener(NpmCompileProjectListener);
 
-    stagingDeploy.with(kubernetesDeployRegistrationProd);
-    productionDeploy.with(kubernetesDeployRegistrationProd);
-    productionDeployWithApproval.with(kubernetesDeployRegistrationProd);
-    globalStagingDeploy.with(kubernetesDeployRegistrationGlobal);
-    globalProductionDeploy.with(kubernetesDeployRegistrationGlobal);
-    demoProductionDeploy.with(kubernetesDeployRegistrationDemo);
-
-    releaseNpm.with({
+    release.with({
         ...NodeDefaultOptions,
         name: "npm-release",
         goalExecutor: executeReleaseNpm(
@@ -236,13 +253,13 @@ export function addNodeSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMa
     releaseDocs.with({
         ...NodeDefaultOptions,
         name: "npm-docs-release",
-        goalExecutor: executeReleaseDocs(DocsReleasePreparations),
+        goalExecutor: executeReleaseTypeDocs(DocsReleasePreparations),
     });
 
     releaseVersion.with({
         ...NodeDefaultOptions,
         name: "npm-release-version",
-        goalExecutor: executeReleaseVersion(NodeProjectIdentifier),
+        goalExecutor: executeReleaseVersion(NodeProjectIdentifier, npmIncrementPatch),
     });
 
     sdm.addFirstPushListener(tagRepo(AutomationClientTagger));
@@ -261,4 +278,298 @@ export function addNodeSupport(sdm: SoftwareDeliveryMachine): SoftwareDeliveryMa
         .addCodeTransformCommand(RenameTest);
 
     return sdm;
+}
+
+/**
+ * Increment the patch version of a Node project managed by NPM.
+ */
+async function npmIncrementPatch(p: GitProject, log: ProgressLog): Promise<ExecuteGoalResult> {
+    return spawnLog("npm", ["version", "--no-git-tag-version", "patch"], { cwd: p.baseDir, log });
+}
+
+function npmPackageUrl(p: ProjectRegistryInfo): string {
+    return `${p.registry}/${p.name}/-/${p.name}-${p.version}.tgz`;
+}
+
+/**
+ * Information about local NPM package tgz file.
+ */
+export interface NpmPackageInfo {
+    /** Local file system path to package tgz */
+    path: string;
+    /** URL where package was downloaded from */
+    url: string;
+    /** Version of package */
+    version: string;
+}
+
+/**
+ * Download the pre-release NPM package related to this project and
+ * goal invocation and provide information back about it.  The caller
+ * is responsible for cleaning up the downloaded files and its parent
+ * directory.
+ *
+ * @param p Project to download NPM package for
+ * @param gi Download package generated by this goal invocation
+ * @return information about the NPM package
+ */
+export async function downloadNpmPackage(p: GitProject, gi: GoalInvocation, v?: string): Promise<NpmPackageInfo> {
+    const pjFile = await p.getFile("package.json");
+    if (!pjFile) {
+        const msg = `NPM project does not have a package.json`;
+        logger.error(msg);
+        throw new Error(msg);
+    }
+    const pjContents = await pjFile.getContent();
+    let pj: { name: string };
+    try {
+        pj = JSON.parse(pjContents);
+    } catch (e) {
+        e.message = `Unable to parse package.json '${pjContents}': ${e.message}`;
+        logger.error(e.message);
+        throw e;
+    }
+    if (!pj.name) {
+        const msg = `Unable to get NPM package name from package.json '${pjContents}'`;
+        logger.error(msg);
+        throw new Error(msg);
+    }
+    const pkgVersion = (v) ? v : await rwlcVersion(gi);
+    const npmOptions = configurationValue<NpmOptions>("sdm.npm");
+    if (!npmOptions.registry) {
+        throw new Error(`No NPM registry defined in NPM options`);
+    }
+    const pkgUrl = npmPackageUrl({
+        registry: npmOptions.registry,
+        name: pj.name,
+        version: pkgVersion,
+    });
+    const tmpDir = path.join((process.env.TMPDIR || "/tmp"), `${p.name}-${guid()}`);
+    const tgz = path.join(tmpDir, "package.tgz");
+
+    const cmds: SpawnWatchCommand[] = [
+        {
+            cmd: { command: "curl", args: ["--output", tgz, "--silent", "--fail", "--create-dirs", pkgUrl] },
+        },
+    ];
+    const els = cmds.map(spawnExecuteLogger);
+    const result = await executeLoggers(els, gi.progressLog);
+    if (result.code !== 0) {
+        throw new Error(`Failed to download NPM package ${pkgUrl}: ${result.message}`);
+    }
+    return {
+        path: tgz,
+        url: pkgUrl,
+        version: pkgVersion,
+    };
+}
+
+/**
+ * Download published pre-release NPM package, replace the contents of
+ * project with the contents of the package, and set the version to
+ * the release version.
+ */
+export async function npmReleasePreparation(p: GitProject, gi: GoalInvocation): Promise<ExecuteGoalResult> {
+    const pkgInfo = await downloadNpmPackage(p, gi);
+    const versionRelease = releaseOrPreRelease(pkgInfo.version, gi);
+    const tmpDir = path.dirname(pkgInfo.path);
+    const cmds: SpawnWatchCommand[] = [
+        {
+            cmd: { command: "tar", args: ["-x", "-z", "-f", pkgInfo.path] },
+            cwd: tmpDir,
+        },
+        {
+            cmd: { command: "bash", args: ["-c", "rm -r *"] },
+            cwd: p.baseDir,
+        },
+        {
+            cmd: { command: "cp", args: ["-r", "package/.", p.baseDir] },
+            cwd: tmpDir,
+        },
+        {
+            cmd: { command: "npm", args: ["--no-git-tag-version", "version", versionRelease] },
+            cwd: p.baseDir,
+        },
+        {
+            cmd: { command: "rm", args: ["-rf", tmpDir] },
+        },
+    ];
+    const els = cmds.map(spawnExecuteLogger);
+    return executeLoggers(els, gi.progressLog);
+}
+
+export const NpmReleasePreparations: PrepareForGoalExecution[] = [npmReleasePreparation];
+
+export function executeReleaseNpm(
+    projectIdentifier: ProjectIdentifier,
+    preparations: PrepareForGoalExecution[] = NpmReleasePreparations,
+    options?: NpmOptions,
+): ExecuteGoal {
+
+    if (!options.npmrc) {
+        throw new Error(`No npmrc defined in NPM options`);
+    }
+    return async (gi: GoalInvocation) => {
+        const { configuration, credentials, id, context } = gi;
+        return configuration.sdm.projectLoader.doWithProject({
+            credentials,
+            id,
+            context,
+            readOnly: false,
+        }, async (project: GitProject) => {
+
+            if (!(await projectConfigurationValue<boolean>("npm.publish.enabled", project, true))) {
+                return {
+                    code: 0,
+                    description: "Publish disabled",
+                    state: SdmGoalState.success,
+                };
+            }
+
+            await fs.writeFile(path.join(project.baseDir, ".npmrc"), options.npmrc);
+
+            for (const preparation of preparations) {
+                const pResult = await preparation(project, gi);
+                if (pResult && pResult.code !== 0) {
+                    return pResult;
+                }
+            }
+            const args = [
+                "publish",
+                "--registry", options.registry,
+                "--access", options.access ? options.access : "restricted",
+            ];
+            const v = await rwlcVersion(gi);
+            const versionRelease = releaseOrPreRelease(v, gi);
+            if (isNextVersion(versionRelease)) {
+                args.push(
+                    "--tag", "next",
+                );
+            }
+            const result = await spawnLog(
+                "npm",
+                args,
+                {
+                    cwd: project.baseDir,
+                    log: gi.progressLog,
+                });
+            if (result.error) {
+                return result;
+            }
+
+            const pi = await projectIdentifier(project);
+            const url = npmPackageUrl({
+                registry: options.registry,
+                name: pi.name,
+                version: pi.version,
+            });
+            if (options.status) {
+                await github.createStatus(
+                    (credentials as TokenCredentials).token,
+                    id as GitHubRepoRef,
+                    {
+                        context: "npm/atomist/package",
+                        description: "NPM package",
+                        target_url: url,
+                        state: "success",
+                    });
+            }
+
+            const egr: ExecuteGoalResult = {
+                code: result.code,
+                message: result.message,
+                targetUrl: url,
+            };
+            return egr;
+        });
+    };
+}
+
+function typedocDir(baseDir: string): string {
+    const oldDir = path.join(baseDir, "build", "typedoc");
+    const dir = path.join(baseDir, "doc");
+    if (fs.existsSync(oldDir)) {
+        return oldDir;
+    }
+    return dir;
+}
+
+export async function docsReleasePreparation(p: GitProject, gi: GoalInvocation): Promise<ExecuteGoalResult> {
+    const cmds: SpawnWatchCommand[] = [
+        {
+            cmd: {
+                command: "npm",
+                args: ["ci"],
+                options: {
+                    ...DevelopmentEnvOptions,
+                    log: gi.progressLog,
+                },
+            },
+            cwd: p.baseDir,
+        },
+        {
+            cmd: { command: "npm", args: ["run", "compile"] },
+            cwd: p.baseDir,
+        },
+        {
+            cmd: { command: "npm", args: ["run", "doc"] },
+            cwd: p.baseDir,
+        },
+    ];
+    const els = cmds.map(spawnExecuteLogger);
+    return executeLoggers(els, gi.progressLog);
+}
+
+export const DocsReleasePreparations: PrepareForGoalExecution[] = [docsReleasePreparation];
+
+/**
+ * Publish TypeDoc to gh-pages branch.
+ */
+export function executeReleaseTypeDocs(preparations: PrepareForGoalExecution[] = DocsReleasePreparations): ExecuteGoal {
+
+    return async (gi: GoalInvocation) => {
+        const { configuration, credentials, id, context } = gi;
+        return configuration.sdm.projectLoader.doWithProject({
+            credentials,
+            id,
+            context,
+            readOnly: false,
+        }, async (project: GitProject) => {
+
+            for (const preparation of preparations) {
+                const pResult = await preparation(project, gi);
+                if (pResult && pResult.code !== 0) {
+                    return pResult;
+                }
+            }
+
+            const v = await rwlcVersion(gi);
+            const versionRelease = releaseOrPreRelease(v, gi);
+            const commitMsg = `TypeDoc: publishing for version ${versionRelease}
+
+[atomist:generated]`;
+            const docDir = typedocDir(project.baseDir);
+            const els = [spawnExecuteLogger({
+                cmd: { command: "touch", args: [path.join(docDir, ".nojekyll")] },
+                cwd: project.baseDir,
+            })];
+            const docProject = await NodeFsLocalProject.fromExistingDirectory(project.id, docDir);
+            const docGitProject = GitCommandGitProject.fromProject(docProject, credentials) as GitCommandGitProject;
+            const targetUrl = `https://${docGitProject.id.owner}.github.io/${docGitProject.id.repo}`;
+            const rrr = project.id as RemoteRepoRef;
+
+            els.push(
+                gitExecuteLogger(docGitProject, () => docGitProject.init(), "init"),
+                gitExecuteLogger(docGitProject, () => docGitProject.commit(commitMsg), "commit"),
+                gitExecuteLogger(docGitProject, () => docGitProject.createBranch("gh-pages"), "createBranch"),
+                gitExecuteLogger(docGitProject, () => docGitProject.setRemote(rrr.cloneUrl(credentials)), "setRemote"),
+                gitExecuteLogger(docGitProject, () => docGitProject.push({ force: true }), "push"),
+            );
+            const gitRes = await executeLoggers(els, gi.progressLog);
+            if (gitRes.code !== 0) {
+                return gitRes;
+            }
+            return { ...Success, targetUrl };
+        });
+    };
 }

--- a/lib/machine/release.ts
+++ b/lib/machine/release.ts
@@ -14,16 +14,11 @@
  * limitations under the License.
  */
 
-// tslint:disable:max-file-line-count
-
 import {
-    configurationValue,
     GitCommandGitProject,
     GitHubRepoRef,
     GitProject,
-    guid,
     logger,
-    NodeFsLocalProject,
     RemoteRepoRef,
     Success,
     TokenCredentials,
@@ -32,15 +27,11 @@ import {
     DelimitedWriteProgressLogDecorator,
     ExecuteGoal,
     ExecuteGoalResult,
+    formatDate,
     GoalInvocation,
-    PrepareForGoalExecution,
     ProgressLog,
-    projectConfigurationValue,
     PushTest,
-    SdmGoalState,
-    spawnLog,
-    SpawnLogCommand,
-    SpawnLogOptions,
+    SdmGoalEvent,
 } from "@atomist/sdm";
 import {
     createTagForStatus,
@@ -48,15 +39,14 @@ import {
     ProjectIdentifier,
     readSdmVersion,
 } from "@atomist/sdm-core";
-import { DockerOptions } from "@atomist/sdm-pack-docker";
-import {
-    DevelopmentEnvOptions,
-    NpmOptions,
-} from "@atomist/sdm-pack-node";
-import * as fs from "fs-extra";
 import * as _ from "lodash";
-import * as path from "path";
 import * as semver from "semver";
+import {
+    ExecuteLogger,
+    executeLoggers,
+    gitExecuteLogger,
+    spawnExecuteLogger,
+} from "../support/executeLogger";
 
 async function loglog(log: ProgressLog, msg: string): Promise<void> {
     logger.debug(msg);
@@ -64,7 +54,7 @@ async function loglog(log: ProgressLog, msg: string): Promise<void> {
     await log.flush();
 }
 
-interface ProjectRegistryInfo {
+export interface ProjectRegistryInfo {
     registry: string;
     name: string;
     version: string;
@@ -106,373 +96,25 @@ function preReleaseVersion(gi: GoalInvocation): string | undefined {
     }
 }
 
-function isNextVersion(version: string): boolean {
+/**
+ * Make a release version a branch-aware pre-release version.
+ */
+export function addBranchPreRelease(baseVersion: string, goalEvent: SdmGoalEvent): string {
+    const branch = goalEvent.branch;
+    const branchSuffix = (branch === goalEvent.push.repo.defaultBranch) ? "" :
+        "branch-" + branch.replace(/[_/]/g, "-") + ".";
+    const ts = formatDate();
+    const prereleaseVersion = `${baseVersion}-${branchSuffix}${ts}`;
+    return prereleaseVersion;
+}
+
+export function isNextVersion(version: string): boolean {
     const preRelease = semver.prerelease(version);
     return (preRelease && ["M", "RC"].includes(preRelease[0]));
 }
 
 function releaseVersion(version: string): string {
     return version.replace(/-.*/, "");
-}
-
-function npmPackageUrl(p: ProjectRegistryInfo): string {
-    return `${p.registry}/${p.name}/-/${p.name}-${p.version}.tgz`;
-}
-
-function dockerImage(p: ProjectRegistryInfo): string {
-    return `${p.registry}/${p.name}:${p.version}`;
-}
-
-type ExecuteLogger = (l: ProgressLog) => Promise<ExecuteGoalResult>;
-
-interface SpawnWatchCommand {
-    cmd: SpawnLogCommand;
-    cwd?: string;
-}
-
-/**
- * Transform a SpawnWatchCommand into an ExecuteLogger suitable for
- * execution by executeLoggers.  The operation is awaited and any
- * thrown exceptions are caught and transformed into an error result.
- * If an error occurs, it is logged.  The result of the operation is
- * transformed into a ExecuteGoalResult.  If an exception is caught,
- * the returned code is guaranteed to be non-zero.
- */
-function spawnExecuteLogger(swc: SpawnWatchCommand): ExecuteLogger {
-
-    return async (log: ProgressLog) => {
-        const opts: SpawnLogOptions = {
-            ...swc.cmd.options,
-            log,
-        };
-        if (swc.cwd) {
-            opts.cwd = swc.cwd;
-        }
-        let res;
-        try {
-            res = await spawnLog(swc.cmd.command, swc.cmd.args, opts);
-        } catch (e) {
-            res = {
-                code: -1,
-                message: `Spawned command errored: ${swc.cmd.command} ${swc.cmd.args.join(" ")}: ${e.message}`,
-            };
-        }
-        if (res.error) {
-            if (!res.message) {
-                res.message = `Spawned command failed (status:${res.code}): ${swc.cmd.command} ${swc.cmd.args.join(" ")}`;
-            }
-            logger.error(res.message);
-            log.write(res.message);
-        }
-        return res;
-    };
-}
-
-/**
- * Transform a GitCommandGitProject operation into an ExecuteLogger
- * suitable for execution by executeLoggers.  The operation is awaited
- * and any thrown exceptions are caught and transformed into an error
- * result.  The returned standard out and standard error are written
- * to the log.  If an error occurs, it is logged.  The result of the
- * operation is transformed into a ExecuteGoalResult.  If an error is
- * returned or exception caught, the returned code is guaranteed to be
- * non-zero.
- */
-function gitExecuteLogger(
-    gp: GitCommandGitProject,
-    op: () => Promise<GitCommandGitProject>,
-    name: string,
-): ExecuteLogger {
-
-    return async (log: ProgressLog) => {
-        log.write(`Running: git ${name}`);
-        try {
-            await op();
-            log.write(`Success: git ${name}`);
-            return { code: 0 };
-        } catch (e) {
-            log.write(e.stdout);
-            log.write(e.stderr);
-            const message = `Failure: git ${name}: ${e.message}`;
-            log.write(message);
-            return {
-                code: e.code,
-                message,
-            };
-        }
-    };
-}
-
-/**
- * Execute an array of logged commands, creating a line-delimited
- * progress log beforehand, flushing after each command, and closing
- * it at the end.  If any command fails, bail out and return the
- * failure result.  Otherwise return Success.
- */
-async function executeLoggers(els: ExecuteLogger[], progressLog: ProgressLog): Promise<ExecuteGoalResult> {
-    const log = new DelimitedWriteProgressLogDecorator(progressLog, "\n");
-    for (const cmd of els) {
-        const res = await cmd(log);
-        await log.flush();
-        if (res.code !== 0) {
-            return res;
-        }
-    }
-    return Success;
-}
-
-/**
- * Information about local NPM package tgz file.
- */
-export interface NpmPackageInfo {
-    /** Local file system path to package tgz */
-    path: string;
-    /** URL where package was downloaded from */
-    url: string;
-    /** Version of package */
-    version: string;
-}
-
-/**
- * Download the pre-release NPM package related to this project and
- * goal invocation and provide information back about it.  The caller
- * is responsible for cleaning up the downloaded files and its parent
- * directory.
- *
- * @param p Project to download NPM package for
- * @param gi Download package generated by this goal invocation
- * @return information about the NPM package
- */
-export async function downloadNpmPackage(p: GitProject, gi: GoalInvocation, version?: string): Promise<NpmPackageInfo> {
-    const pjFile = await p.getFile("package.json");
-    if (!pjFile) {
-        const msg = `NPM project does not have a package.json`;
-        logger.error(msg);
-        throw new Error(msg);
-    }
-    const pjContents = await pjFile.getContent();
-    let pj: { name: string };
-    try {
-        pj = JSON.parse(pjContents);
-    } catch (e) {
-        e.message = `Unable to parse package.json '${pjContents}': ${e.message}`;
-        logger.error(e.message);
-        throw e;
-    }
-    if (!pj.name) {
-        const msg = `Unable to get NPM package name from package.json '${pjContents}'`;
-        logger.error(msg);
-        throw new Error(msg);
-    }
-    const pkgVersion = (version) ? version : await rwlcVersion(gi);
-    const npmOptions = configurationValue<NpmOptions>("sdm.npm");
-    if (!npmOptions.registry) {
-        throw new Error(`No NPM registry defined in NPM options`);
-    }
-    const pkgUrl = npmPackageUrl({
-        registry: npmOptions.registry,
-        name: pj.name,
-        version: pkgVersion,
-    });
-    const tmpDir = path.join((process.env.TMPDIR || "/tmp"), `${p.name}-${guid()}`);
-    const tgz = path.join(tmpDir, "package.tgz");
-
-    const cmds: SpawnWatchCommand[] = [
-        {
-            cmd: { command: "curl", args: ["--output", tgz, "--silent", "--fail", "--create-dirs", pkgUrl] },
-        },
-    ];
-    const els = cmds.map(spawnExecuteLogger);
-    const result = await executeLoggers(els, gi.progressLog);
-    if (result.code !== 0) {
-        throw new Error(`Failed to download NPM package ${pkgUrl}: ${result.message}`);
-    }
-    return {
-        path: tgz,
-        url: pkgUrl,
-        version: pkgVersion,
-    };
-}
-
-/**
- * Download published pre-release NPM package, replace the contents of
- * project with the contents of the package, and set the version to
- * the release version.
- */
-export async function npmReleasePreparation(p: GitProject, gi: GoalInvocation): Promise<ExecuteGoalResult> {
-    const pkgInfo = await downloadNpmPackage(p, gi);
-    const versionRelease = releaseOrPreRelease(pkgInfo.version, gi);
-    const tmpDir = path.dirname(pkgInfo.path);
-    const cmds: SpawnWatchCommand[] = [
-        {
-            cmd: { command: "tar", args: ["-x", "-z", "-f", pkgInfo.path] },
-            cwd: tmpDir,
-        },
-        {
-            cmd: { command: "bash", args: ["-c", "rm -r *"] },
-            cwd: p.baseDir,
-        },
-        {
-            cmd: { command: "cp", args: ["-r", "package/.", p.baseDir] },
-            cwd: tmpDir,
-        },
-        {
-            cmd: { command: "npm", args: ["--no-git-tag-version", "version", versionRelease] },
-            cwd: p.baseDir,
-        },
-        {
-            cmd: { command: "rm", args: ["-rf", tmpDir] },
-        },
-    ];
-    const els = cmds.map(spawnExecuteLogger);
-    return executeLoggers(els, gi.progressLog);
-}
-
-export const NpmReleasePreparations: PrepareForGoalExecution[] = [npmReleasePreparation];
-
-export function executeReleaseNpm(
-    projectIdentifier: ProjectIdentifier,
-    preparations: PrepareForGoalExecution[] = NpmReleasePreparations,
-    options?: NpmOptions,
-): ExecuteGoal {
-
-    if (!options.npmrc) {
-        throw new Error(`No npmrc defined in NPM options`);
-    }
-    return async (gi: GoalInvocation) => {
-        const { configuration, credentials, id, context } = gi;
-        return configuration.sdm.projectLoader.doWithProject({
-            credentials,
-            id,
-            context,
-            readOnly: false,
-        }, async (project: GitProject) => {
-
-            if (!(await projectConfigurationValue<boolean>("npm.publish.enabled", project, true))) {
-                return {
-                    code: 0,
-                    description: "Publish disabled",
-                    state: SdmGoalState.success,
-                };
-            }
-
-            await fs.writeFile(path.join(project.baseDir, ".npmrc"), options.npmrc);
-
-            for (const preparation of preparations) {
-                const pResult = await preparation(project, gi);
-                if (pResult && pResult.code !== 0) {
-                    return pResult;
-                }
-            }
-            const args = [
-                "publish",
-                "--registry", options.registry,
-                "--access", options.access ? options.access : "restricted",
-            ];
-            const version = await rwlcVersion(gi);
-            const versionRelease = releaseOrPreRelease(version, gi);
-            if (isNextVersion(versionRelease)) {
-                args.push(
-                    "--tag", "next",
-                );
-            }
-            const result = await spawnLog(
-                "npm",
-                args,
-                {
-                    cwd: project.baseDir,
-                    log: gi.progressLog,
-                });
-            if (result.error) {
-                return result;
-            }
-
-            const pi = await projectIdentifier(project);
-            const url = npmPackageUrl({
-                registry: options.registry,
-                name: pi.name,
-                version: pi.version,
-            });
-            if (options.status) {
-                await github.createStatus(
-                    (credentials as TokenCredentials).token,
-                    id as GitHubRepoRef,
-                    {
-                        context: "npm/atomist/package",
-                        description: "NPM package",
-                        target_url: url,
-                        state: "success",
-                    });
-            }
-
-            const egr: ExecuteGoalResult = {
-                code: result.code,
-                message: result.message,
-                targetUrl: url,
-            };
-            return egr;
-        });
-    };
-}
-
-export function executeReleaseDocker(
-    options?: DockerOptions,
-): ExecuteGoal {
-
-    return async (gi: GoalInvocation) => {
-        if (!options.registry) {
-            throw new Error(`No registry defined in Docker options`);
-        }
-        const version = await rwlcVersion(gi);
-        const image = dockerImage({
-            registry: options.registry,
-            name: gi.goalEvent.repo.name,
-            version,
-        });
-
-        const loginArgs = [];
-        if (/[^A-Za-z0-9]/.test(options.registry)) {
-            loginArgs.push(options.registry);
-        }
-
-        const loginCmds: SpawnWatchCommand[] = [
-            {
-                cmd: {
-                    command: "docker",
-                    args: ["login", "--username", options.user, "--password", options.password, ...loginArgs],
-                },
-            },
-            {
-                cmd: { command: "docker", args: ["pull", image] },
-            },
-        ];
-        let els = loginCmds.map(spawnExecuteLogger);
-        const result = await executeLoggers(els, gi.progressLog);
-        if (result.code !== 0) {
-            return result;
-        }
-
-        const versionRelease = releaseOrPreRelease(version, gi);
-        const tag = dockerImage({
-            registry: options.registry,
-            name: gi.goalEvent.repo.name,
-            version: versionRelease,
-        });
-
-        const cmds: SpawnWatchCommand[] = [
-            {
-                cmd: { command: "docker", args: ["tag", image, tag] },
-            },
-            {
-                cmd: { command: "docker", args: ["push", tag] },
-            },
-            {
-                cmd: { command: "docker", args: ["rmi", tag] },
-            },
-        ];
-        els = cmds.map(spawnExecuteLogger);
-        return executeLoggers(els, gi.progressLog);
-    };
 }
 
 /**
@@ -505,104 +147,12 @@ export function executeReleaseTag(): ExecuteGoal {
     };
 }
 
-function typedocDir(baseDir: string): string {
-    const oldDir = path.join(baseDir, "build", "typedoc");
-    const dir = path.join(baseDir, "doc");
-    if (fs.existsSync(oldDir)) {
-        return oldDir;
-    }
-    return dir;
-}
-
-export async function docsReleasePreparation(p: GitProject, gi: GoalInvocation): Promise<ExecuteGoalResult> {
-    const cmds: SpawnWatchCommand[] = [
-        {
-            cmd: {
-                command: "npm",
-                args: ["ci"],
-                options: {
-                    ...DevelopmentEnvOptions,
-                    log: gi.progressLog,
-                },
-            },
-            cwd: p.baseDir,
-        },
-        {
-            cmd: { command: "npm", args: ["run", "compile"] },
-            cwd: p.baseDir,
-        },
-        {
-            cmd: { command: "npm", args: ["run", "doc"] },
-            cwd: p.baseDir,
-        },
-    ];
-    const els = cmds.map(spawnExecuteLogger);
-    return executeLoggers(els, gi.progressLog);
-}
-
-export const DocsReleasePreparations: PrepareForGoalExecution[] = [docsReleasePreparation];
-
-/**
- * Publish TypeDoc to gh-pages branch.
- */
-export function executeReleaseDocs(
-    preparations: PrepareForGoalExecution[] = DocsReleasePreparations,
-): ExecuteGoal {
-
-    return async (gi: GoalInvocation) => {
-        const { configuration, credentials, id, context } = gi;
-        return configuration.sdm.projectLoader.doWithProject({
-            credentials,
-            id,
-            context,
-            readOnly: false,
-        }, async (project: GitProject) => {
-
-            for (const preparation of preparations) {
-                const pResult = await preparation(project, gi);
-                if (pResult && pResult.code !== 0) {
-                    return pResult;
-                }
-            }
-
-            const version = await rwlcVersion(gi);
-            const versionRelease = releaseOrPreRelease(version, gi);
-            const commitMsg = `TypeDoc: publishing for version ${versionRelease}
-
-[atomist:generated]`;
-            const docDir = typedocDir(project.baseDir);
-            const els = [spawnExecuteLogger({
-                cmd: { command: "touch", args: [path.join(docDir, ".nojekyll")] },
-                cwd: project.baseDir,
-            })];
-            const docProject = await NodeFsLocalProject.fromExistingDirectory(project.id, docDir);
-            const docGitProject = GitCommandGitProject.fromProject(docProject, credentials) as GitCommandGitProject;
-            const targetUrl = `https://${docGitProject.id.owner}.github.io/${docGitProject.id.repo}`;
-            const rrr = project.id as RemoteRepoRef;
-
-            els.push(
-                gitExecuteLogger(docGitProject, () => docGitProject.init(), "init"),
-                gitExecuteLogger(docGitProject, () => docGitProject.commit(commitMsg), "commit"),
-                gitExecuteLogger(docGitProject, () => docGitProject.createBranch("gh-pages"), "createBranch"),
-                gitExecuteLogger(docGitProject, () => docGitProject.setRemote(rrr.cloneUrl(credentials)), "setRemote"),
-                gitExecuteLogger(docGitProject, () => docGitProject.push({ force: true }), "push"),
-            );
-            const gitRes = await executeLoggers(els, gi.progressLog);
-            if (gitRes.code !== 0) {
-                return gitRes;
-            }
-            return { ...Success, targetUrl };
-        });
-    };
-}
+export type IncrementPatchCommand = (p: GitProject, log: ProgressLog) => Promise<ExecuteGoalResult>;
 
 /**
  * Increment patch level in project version.
  */
-export function executeReleaseVersion(
-    projectIdentifier: ProjectIdentifier,
-    incrementPatchCmd: SpawnLogCommand = { command: "npm", args: ["version", "--no-git-tag-version", "patch"] },
-): ExecuteGoal {
+export function executeReleaseVersion(projectIdentifier: ProjectIdentifier, incrementPatchCmd: IncrementPatchCommand): ExecuteGoal {
 
     return async (gi: GoalInvocation): Promise<ExecuteGoalResult> => {
         const { configuration, credentials, id, context } = gi;
@@ -635,8 +185,12 @@ export function executeReleaseVersion(
                 return { ...Success, message };
             }
 
+            const incrementPatchResult = await incrementPatchCmd(gp, log);
+            if (incrementPatchResult.code !== 0) {
+                return incrementPatchResult;
+            }
+
             const postEls: ExecuteLogger[] = [
-                spawnExecuteLogger({ cmd: incrementPatchCmd, cwd: gp.baseDir }),
                 gitExecuteLogger(gp, () => gp.commit(`Version: increment after ${versionRelease} release
 
 [atomist:generated]`), "commit"),

--- a/lib/machine/webSupport.ts
+++ b/lib/machine/webSupport.ts
@@ -35,7 +35,7 @@ import {
     GoalProjectListenerEvent,
     GoalProjectListenerRegistration,
     LogSuppressor,
-    PushTest,
+    pushTest,
     spawnLog,
     SpawnLogCommand,
     SpawnLogOptions,
@@ -47,10 +47,7 @@ import {
 import * as fs from "fs-extra";
 import * as path from "path";
 
-export const IsJekyllProject: PushTest = {
-    name: "IsJekyllProject",
-    mapping: inv => inv.project.hasFile("_config.yml"),
-};
+export const IsJekyllProject = pushTest("IsJekyllProject", inv => inv.project.hasFile("_config.yml"));
 
 const webNpmCommands: SpawnLogCommand[] = [
     { command: "npm", args: ["ci"], options: { env: { ...process.env, NODE_ENV: "development" }, log: undefined } },

--- a/lib/support/executeLogger.ts
+++ b/lib/support/executeLogger.ts
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    GitCommandGitProject,
+    logger,
+    Success,
+} from "@atomist/automation-client";
+import {
+    DelimitedWriteProgressLogDecorator,
+    ExecuteGoalResult,
+    ProgressLog,
+    spawnLog,
+    SpawnLogCommand,
+    SpawnLogOptions,
+} from "@atomist/sdm";
+
+export async function loglog(log: ProgressLog, msg: string): Promise<void> {
+    logger.debug(msg);
+    log.write(`${msg}\n`);
+    await log.flush();
+}
+
+export type ExecuteLogger = (l: ProgressLog) => Promise<ExecuteGoalResult>;
+
+export interface SpawnWatchCommand {
+    cmd: SpawnLogCommand;
+    cwd?: string;
+}
+
+/**
+ * Transform a SpawnWatchCommand into an ExecuteLogger suitable for
+ * execution by executeLoggers.  The operation is awaited and any
+ * thrown exceptions are caught and transformed into an error result.
+ * If an error occurs, it is logged.  The result of the operation is
+ * transformed into a ExecuteGoalResult.  If an exception is caught,
+ * the returned code is guaranteed to be non-zero.
+ */
+export function spawnExecuteLogger(swc: SpawnWatchCommand): ExecuteLogger {
+
+    return async (log: ProgressLog) => {
+        const opts: SpawnLogOptions = {
+            ...swc.cmd.options,
+            log,
+        };
+        if (swc.cwd) {
+            opts.cwd = swc.cwd;
+        }
+        let res;
+        try {
+            res = await spawnLog(swc.cmd.command, swc.cmd.args, opts);
+        } catch (e) {
+            res = {
+                code: -1,
+                message: `Spawned command errored: ${swc.cmd.command} ${swc.cmd.args.join(" ")}: ${e.message}`,
+            };
+        }
+        if (res.error) {
+            if (!res.message) {
+                res.message = `Spawned command failed (status:${res.code}): ${swc.cmd.command} ${swc.cmd.args.join(" ")}`;
+            }
+            logger.error(res.message);
+            log.write(res.message);
+        }
+        return res;
+    };
+}
+
+/**
+ * Transform a GitCommandGitProject operation into an ExecuteLogger
+ * suitable for execution by executeLoggers.  The operation is awaited
+ * and any thrown exceptions are caught and transformed into an error
+ * result.  The returned standard out and standard error are written
+ * to the log.  If an error occurs, it is logged.  The result of the
+ * operation is transformed into a ExecuteGoalResult.  If an error is
+ * returned or exception caught, the returned code is guaranteed to be
+ * non-zero.
+ */
+export function gitExecuteLogger(
+    gp: GitCommandGitProject,
+    op: () => Promise<GitCommandGitProject>,
+    name: string,
+): ExecuteLogger {
+
+    return async (log: ProgressLog) => {
+        log.write(`Running: git ${name}`);
+        try {
+            await op();
+            log.write(`Success: git ${name}`);
+            return { code: 0 };
+        } catch (e) {
+            log.write(e.stdout);
+            log.write(e.stderr);
+            const message = `Failure: git ${name}: ${e.message}`;
+            log.write(message);
+            return {
+                code: e.code,
+                message,
+            };
+        }
+    };
+}
+
+/**
+ * Execute an array of logged commands, creating a line-delimited
+ * progress log beforehand, flushing after each command, and closing
+ * it at the end.  If any command fails, bail out and return the
+ * failure result.  Otherwise return Success.
+ */
+export async function executeLoggers(els: ExecuteLogger[], progressLog: ProgressLog): Promise<ExecuteGoalResult> {
+    const log = new DelimitedWriteProgressLogDecorator(progressLog, "\n");
+    for (const cmd of els) {
+        const res = await cmd(log);
+        await log.flush();
+        if (res.code !== 0) {
+            return res;
+        }
+    }
+    return Success;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/atomist-sdm",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -564,9 +564,9 @@
       }
     },
     "@atomist/sdm-pack-docker": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-docker/-/sdm-pack-docker-1.1.0.tgz",
-      "integrity": "sha512-b07yCDN81z8NPJ9lh2Q7k4ukTFALWjKa4vT5TUQIM0AdlWmXkXfdUHYhkvcptWA9YcDqEVr4tVDSjM0AGgCFJg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm-pack-docker/-/sdm-pack-docker-1.2.0.tgz",
+      "integrity": "sha512-pWzjFIakznZcU9MuLOHsef8EWd0WDzjYdjEmoTGEZ0zktxl42l8DL6rCKJrbsIQ587KlHf2e4LGKZ9FuJEW8Jg==",
       "requires": {
         "@atomist/tree-path": "^1.0.3",
         "@types/fs-extra": "^5.0.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomist/atomist-sdm",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Atomist SDM to deliver our own projects",
   "author": {
     "name": "Atomist",
@@ -32,7 +32,7 @@
     "@atomist/sdm-pack-analysis": "^1.0.0",
     "@atomist/sdm-pack-build": "^1.0.4",
     "@atomist/sdm-pack-changelog": "^1.0.2",
-    "@atomist/sdm-pack-docker": "^1.1.0",
+    "@atomist/sdm-pack-docker": "^1.2.0",
     "@atomist/sdm-pack-fingerprints": "^2.0.2",
     "@atomist/sdm-pack-issue": "^1.2.1",
     "@atomist/sdm-pack-k8s": "^1.4.1",

--- a/test/machine/goSupport.test.ts
+++ b/test/machine/goSupport.test.ts
@@ -1,0 +1,254 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InMemoryProject } from "@atomist/automation-client";
+import { ProgressLog } from "@atomist/sdm";
+import * as assert from "power-assert";
+import { goIncrementPatch } from "../../lib/machine/goSupport";
+
+describe("machine/go", () => {
+
+    describe("goIncrementPatch", () => {
+
+        it("should increment the patch", async () => {
+            const v = `// Copyright © 2018 Atomist
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	pkg     = "k8vent"
+	version = "0.11.0"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version and exit",
+	Long:  "Print the package name and version in the standard format.",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(pkg, version)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}
+`;
+            const m = `# Makefile for Travis CI
+
+GO = go
+GO_FLAGS = -v
+GO_ARGS = $(shell go list ./...)
+GO_BUILD_ARGS =
+
+TARGET = k8vent
+DOCKER_TARGET = docker/$(TARGET)
+DOCKER_IMAGE = atomist/$(TARGET)
+DOCKER_VERSION = 0.11.0
+DOCKER_TAG = $(DOCKER_IMAGE):$(DOCKER_VERSION)
+
+all: vet
+
+generate:
+	$(GO) generate $(GO_FLAGS) $(GO_ARGS)
+
+build: generate
+	$(GO) build $(GO_FLAGS) $(GO_BUILD_ARGS) -o "$(TARGET)"
+
+test: build
+	$(GO) test $(GO_FLAGS) $(GO_ARGS)
+
+install: test
+	$(GO) install $(GO_FLAGS) $(GO_ARGS)
+
+vet: install
+	$(GO) vet $(GO_FLAGS) $(GO_ARGS)
+
+$(DOCKER_TARGET): clean-local
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_FLAGS) $(GO_BUILD_ARGS) -a --installsuffix cgo --ldflags="-s" -o "$(DOCKER_TARGET)"
+
+docker-target: $(DOCKER_TARGET)
+
+docker-build: docker-target
+	cd docker && docker build -t "$(DOCKER_TAG)" .
+
+docker: docker-build
+	docker push "$(DOCKER_TAG)"
+
+clean: clean-local
+	$(GO) clean $(GO_FLAGS) $(GO_ARGS)
+
+clean-local:
+	-rm -f "$(DOCKER_TARGET)"
+
+.PHONY: all fast clean build test vet
+.PHONY: docker docker-target docker-build docker-push
+.PHONY: clean-local
+`;
+            const p = InMemoryProject.of(
+                { path: "cmd/version.go", content: v },
+                { path: "Makefile", content: m },
+            );
+            const l: ProgressLog = { write: () => { return; } } as any;
+            const r = await goIncrementPatch(p, l);
+            assert(r.code === 0);
+            assert(r.message === "Incremented patch level: 0.11.0 => 0.11.1");
+            const rv = await (await p.getFile("cmd/version.go")).getContent();
+            const ev = `// Copyright © 2018 Atomist
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	pkg     = "k8vent"
+	version = "0.11.1"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version and exit",
+	Long:  "Print the package name and version in the standard format.",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println(pkg, version)
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(versionCmd)
+}
+`;
+            assert(rv === ev);
+            const rm = await (await p.getFile("Makefile")).getContent();
+            const em = `# Makefile for Travis CI
+
+GO = go
+GO_FLAGS = -v
+GO_ARGS = $(shell go list ./...)
+GO_BUILD_ARGS =
+
+TARGET = k8vent
+DOCKER_TARGET = docker/$(TARGET)
+DOCKER_IMAGE = atomist/$(TARGET)
+DOCKER_VERSION = 0.11.1
+DOCKER_TAG = $(DOCKER_IMAGE):$(DOCKER_VERSION)
+
+all: vet
+
+generate:
+	$(GO) generate $(GO_FLAGS) $(GO_ARGS)
+
+build: generate
+	$(GO) build $(GO_FLAGS) $(GO_BUILD_ARGS) -o "$(TARGET)"
+
+test: build
+	$(GO) test $(GO_FLAGS) $(GO_ARGS)
+
+install: test
+	$(GO) install $(GO_FLAGS) $(GO_ARGS)
+
+vet: install
+	$(GO) vet $(GO_FLAGS) $(GO_ARGS)
+
+$(DOCKER_TARGET): clean-local
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 $(GO) build $(GO_FLAGS) $(GO_BUILD_ARGS) -a --installsuffix cgo --ldflags="-s" -o "$(DOCKER_TARGET)"
+
+docker-target: $(DOCKER_TARGET)
+
+docker-build: docker-target
+	cd docker && docker build -t "$(DOCKER_TAG)" .
+
+docker: docker-build
+	docker push "$(DOCKER_TAG)"
+
+clean: clean-local
+	$(GO) clean $(GO_FLAGS) $(GO_ARGS)
+
+clean-local:
+	-rm -f "$(DOCKER_TARGET)"
+
+.PHONY: all fast clean build test vet
+.PHONY: docker docker-target docker-build docker-push
+.PHONY: clean-local
+`;
+            assert(rm === em);
+        });
+
+        it("should fail to find the file", async () => {
+            const p = InMemoryProject.of({ path: "version.go", content: `` });
+            const l: ProgressLog = { write: () => { return; } } as any;
+            const r = await goIncrementPatch(p, l);
+            assert(r.code === 1);
+            assert(r.message === "Project does not have 'cmd/version.go' file");
+        });
+
+        it("should fail to find the version", async () => {
+            const p = InMemoryProject.of(
+                { path: "cmd/version.go", content: `` },
+                { path: "Makefile", content: `` },
+            );
+            const l: ProgressLog = { write: () => { return; } } as any;
+            const r = await goIncrementPatch(p, l);
+            assert(r.code === 1);
+            assert(r.message === "Failed to extract version from 'cmd/version.go' file");
+        });
+
+        it("should fail to find the Makefile", async () => {
+            const p = InMemoryProject.of({ path: "cmd/version.go", content: `\tversion = "16.8.3"` });
+            const l: ProgressLog = { write: () => { return; } } as any;
+            const r = await goIncrementPatch(p, l);
+            assert(r.code === 1);
+            assert(r.message === "Project does not have 'Makefile' file");
+        });
+
+    });
+
+});

--- a/test/machine/k8sSupport.test.ts
+++ b/test/machine/k8sSupport.test.ts
@@ -49,7 +49,7 @@ describe("k8sSupport", () => {
             const d = await kubernetesApplicationData(a, p, g, v);
             const e = {
                 name: "rocknroll",
-                port: 2866,
+                port: undefined,
                 ns: "default",
                 replicas: 1,
             };
@@ -91,7 +91,7 @@ describe("k8sSupport", () => {
             assert(d);
             const e = {
                 name: "rocknroll",
-                port: 2866,
+                port: undefined,
                 ns: "testing",
                 replicas: 1,
             };
@@ -112,7 +112,7 @@ describe("k8sSupport", () => {
             assert(d);
             const e = {
                 name: "rocknroll",
-                port: 2866,
+                port: undefined,
                 ns: "production",
                 replicas: 3,
             };
@@ -121,7 +121,9 @@ describe("k8sSupport", () => {
 
         it("should detect atomist-sdm", async () => {
             const a: KubernetesApplication = {} as any;
-            const p: GitProject = InMemoryProject.of() as any;
+            const p: GitProject = InMemoryProject.of(
+                { path: "package.json", content: '{"dependencies":{"@atomist/automation-client":"*"}}' },
+            ) as any;
             const g: KubernetesDeploy = {} as any;
             const v: SdmGoalEvent = {
                 environment: "2-prod",
@@ -142,7 +144,9 @@ describe("k8sSupport", () => {
 
         it("should detect atomist-internal-sdm", async () => {
             const a: KubernetesApplication = {} as any;
-            const p: GitProject = InMemoryProject.of() as any;
+            const p: GitProject = InMemoryProject.of(
+                { path: "package.json", content: '{"dependencies":{"@atomist/automation-client":"*"}}' },
+            ) as any;
             const g: KubernetesDeploy = {} as any;
             const v: SdmGoalEvent = {
                 environment: "1-staging",
@@ -163,7 +167,9 @@ describe("k8sSupport", () => {
 
         it("should provide an ingress", async () => {
             const a: KubernetesApplication = {} as any;
-            const p: GitProject = InMemoryProject.of() as any;
+            const p: GitProject = InMemoryProject.of(
+                { path: "package.json", content: '{"dependencies":{"@atomist/automation-client":"*"}}' },
+            ) as any;
             const g: KubernetesDeploy = {} as any;
             const v: SdmGoalEvent = {
                 environment: "1-staging",
@@ -195,7 +201,9 @@ describe("k8sSupport", () => {
 
         it("should provide a production ingress", async () => {
             const a: KubernetesApplication = {} as any;
-            const p: GitProject = InMemoryProject.of() as any;
+            const p: GitProject = InMemoryProject.of(
+                { path: "package.json", content: '{"dependencies":{"@atomist/automation-client":"*"}}' },
+            ) as any;
             const g: KubernetesDeploy = {} as any;
             const v: SdmGoalEvent = {
                 environment: "2-prod",
@@ -227,7 +235,9 @@ describe("k8sSupport", () => {
 
         it("should add secret to k8s-sdm deploy", async () => {
             const a: KubernetesApplication = {} as any;
-            const p: GitProject = InMemoryProject.of() as any;
+            const p: GitProject = InMemoryProject.of(
+                { path: "package.json", content: '{"dependencies":{"@atomist/automation-client":"*"}}' },
+            ) as any;
             const g: KubernetesDeploy = {
                 sdm: {
                     configuration: {

--- a/test/machine/version.test.ts
+++ b/test/machine/version.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InMemoryProject } from "@atomist/automation-client";
+import { ProgressLog } from "@atomist/sdm";
+import * as assert from "power-assert";
+import { fileIncrementPatch } from "../../lib/machine/version";
+
+describe("machine/version", () => {
+
+    describe("fileIncrementPatch", () => {
+
+        it("should increment the patch", async () => {
+            const p = InMemoryProject.of({ path: "VERSION", content: "2.7.1828\n" });
+            const l: ProgressLog = { write: () => { return; } } as any;
+            const r = await fileIncrementPatch(p, l);
+            assert(r.code === 0);
+            assert(r.message === "Incremented patch level in 'VERSION' file: 2.7.1828 => 2.7.1829");
+            const c = await (await p.getFile("VERSION")).getContent();
+            const e = "2.7.1829\n";
+            assert(c === e);
+        });
+
+        it("should fail to find the file", async () => {
+            const p = InMemoryProject.of({ path: "lib/VERSION", content: `86.75.309` });
+            const l: ProgressLog = { write: () => { return; } } as any;
+            const r = await fileIncrementPatch(p, l);
+            assert(r.code === 1);
+            assert(r.message === "Project does not have 'VERSION' file");
+        });
+
+        it("should fail to find the version", async () => {
+            const p = InMemoryProject.of({ path: "VERSION", content: `` });
+            const l: ProgressLog = { write: () => { return; } } as any;
+            const r = await fileIncrementPatch(p, l);
+            assert(r.code === 1);
+            assert(r.message === "Failed to extract version from 'VERSION' file");
+        });
+
+        it("should fail to increment an invalid version", async () => {
+            const p = InMemoryProject.of({ path: "VERSION", content: `6.626e-34\n` });
+            const l: ProgressLog = { write: () => { return; } } as any;
+            const r = await fileIncrementPatch(p, l);
+            assert(r.code === 1);
+            assert(r.message === "Failed to increment patch in version '6.626e-34' from 'VERSION' file");
+        });
+
+    });
+
+});


### PR DESCRIPTION
Add golang-go to Docker image.

Add fulfillments for versioning, building, and releasing Go projects
using make.  Some fulfillments are no ops, which is now a defined goal
executor use in several Go and Maven fulfillments.

Refactor releaseVersion to use a function that returns an
ExecuteGoalResult so it is more flexible, testable, and we don't have
to resort to cryptic Bash incantations.

Add k8vent to multi-Kubernetes deployment goal set.

Rename releaseNpm goal to just release since it has Maven and Go
fulfillments.

Update sdm-docker-pack.

Separate release goal interfaces and fulfillments, moving the
fulfillments into the technology-specific support files.

Create GOPATH like structure under project directory with a copy of
the project at the correct play to trick Go into properly building the
project.

Increment minor version for new feature.

Only add port 2866 for automation clients.

Move Kubernetes deploy goal fulfillments to machine.ts.

Closes #119