### PR TITLE
Register the location of an autofix

### DIFF
--- a/lib/autofix/addAtomistHeader.ts
+++ b/lib/autofix/addAtomistHeader.ts
@@ -17,6 +17,7 @@
 import {
     allSatisfied,
     AutofixRegistration,
+    guessSourceLocation,
     hasFileContaining,
     PushTest,
 } from "@atomist/sdm";
@@ -43,5 +44,6 @@ export function addAtomistHeader(name: string,
         // Ignored any parameters passed in, which will be undefined in an autofix, and provide predefined parameters
         transform: addHeaderTransform,
         parametersInstance,
+        registrationSourceLocation: guessSourceLocation(),
     };
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -215,9 +215,9 @@
       }
     },
     "@atomist/sdm": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-1.5.1.tgz",
-      "integrity": "sha512-/6SIWA35UCOuuoy9XuLpo/8m6sHTkRWx0MmJVVLSbhid9AMfKcpXT2sOv0LpZuyWklYBCuUuUvMrLsrDUhRYeg==",
+      "version": "1.5.2-nortissej.autofix-location.20190616160706",
+      "resolved": "https://registry.npmjs.org/@atomist/sdm/-/sdm-1.5.2-nortissej.autofix-location.20190616160706.tgz",
+      "integrity": "sha512-Cht13pXcySVfJPPaxAqHbQBXV5RflmtoUEfSceCuJtaiKuTGrXskT37RX5GDBdZ6PuxbMNaGY1VQY7JmQdsgCA==",
       "requires": {
         "@types/cron": "^1.7.1",
         "@types/dateformat": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@atomist/automation-client-ext-logzio": "^1.0.2",
     "@atomist/automation-client-ext-raven": "^1.0.2",
     "@atomist/microgrammar": "^1.2.0",
-    "@atomist/sdm": "^1.5.1",
+    "@atomist/sdm": "^1.5.2-nortissej.autofix-location.20190616160706",
     "@atomist/sdm-core": "1.5.3-master.20190615133704",
     "@atomist/sdm-pack-analysis": "^1.0.0",
     "@atomist/sdm-pack-build": "^1.0.4",


### PR DESCRIPTION
This lets the Typescript header autofix reveal its location in its commit messages.

This uses https://github.com/atomist/sdm/pull/750