### PR TITLE
Add GCS goal cache support

### DIFF
--- a/.atomist/kubernetes/deployment.json
+++ b/.atomist/kubernetes/deployment.json
@@ -33,6 +33,10 @@
                     "name": "atomist"
                   }
                 }
+              },
+              {
+                "name": "GOOGLE_APPLICATION_CREDENTIALS",
+                "value": "/opt/gcs/credentials.json"
               }
             ],
             "livenessProbe": {
@@ -82,6 +86,11 @@
               {
                 "mountPath": "/opt/data",
                 "name": "data"
+              },
+              {
+                "mountPath": "/opt/gcs",
+                "name": "gcs-credentials",
+                "readOnly": true
               }
             ]
           }
@@ -107,6 +116,12 @@
               "type": "DirectoryOrCreate"
             },
             "name": "data"
+          },
+          {
+            "name": "gcs-credentials",
+            "secret": {
+              "secretName": "gcs-credentials"
+            }
           }
         ]
       }

--- a/index.ts
+++ b/index.ts
@@ -19,10 +19,12 @@ import { configureDashboardNotifications } from "@atomist/automation-client-ext-
 import { configureHumio } from "@atomist/automation-client-ext-humio";
 import { configureRaven } from "@atomist/automation-client-ext-raven";
 import {
+    CompressingGoalCache,
     ConfigureOptions,
     configureSdm,
 } from "@atomist/sdm-core";
 import { machine } from "./lib/machine/machine";
+import { GoogleCloudStorageGoalCacheArchiveStore } from "./lib/support/cache";
 
 const machineOptions: ConfigureOptions = {
     requiredConfigurationValues: [
@@ -56,8 +58,10 @@ export const configuration: Configuration = {
             },
         },
         cache: {
+            bucket: "atm-atomist-sdm-goal-cache-production",
             enabled: true,
-            path: "/opt/data",
+            path: "atomist-sdm-cache",
+            store: new CompressingGoalCache(new GoogleCloudStorageGoalCacheArchiveStore()),
         },
     },
 };

--- a/lib/support/cache.ts
+++ b/lib/support/cache.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+    LeveledLogMethod,
+    logger,
+} from "@atomist/automation-client";
+import {
+    CacheConfiguration,
+    GoalInvocation,
+    ProgressLog,
+} from "@atomist/sdm";
+import { GoalCacheArchiveStore } from "@atomist/sdm-core";
+import { Storage } from "@google-cloud/storage";
+
+export interface GoogleCloudStorageCacheConfiguration extends CacheConfiguration {
+    cache?: {
+        /**
+         * Google Cloud Storage bucket to perist cache entries to.  If
+         * not provided, it defaults to
+         * "sdm-WORKSPACE_ID-SDM_NAME-goal-cache", with "WORKSPACE_ID"
+         * replaced with your Atomist workspace ID and "SDM_NAME"
+         * replaced with the name of the running SDM, converting
+         * letters to lower case and removing all characters that are
+         * not letter, numbers, and dashes (-).  It makes no attempt
+         * to create this bucket, so make sure it exists before trying
+         * to use it.
+         */
+        bucket?: string;
+        /** Set to true to enable goal input/output caching */
+        enabled?: boolean;
+        /** Path prefix, defaults to "goal-cache". */
+        path?: string;
+    };
+}
+
+type GcsOp = (s: Storage, b: string, p: string) => Promise<any>;
+
+/**
+ * Goal archive store that stores the compressed archives in a Google
+ * Cloud Storage bucket.  All failures are caught and logged.  If
+ * retrieval fails, the error is rethrown so the cache-miss listeners
+ * will be invoked.
+ */
+export class GoogleCloudStorageGoalCacheArchiveStore implements GoalCacheArchiveStore {
+
+    public async store(gi: GoalInvocation, classifier: string, archivePath: string): Promise<void> {
+        await this.gcs(gi, classifier, async (storage, bucket, cachePath) => storage.bucket(bucket).upload(archivePath, {
+            destination: cachePath,
+            predefinedAcl: "projectPrivate",
+        }), "store");
+    }
+
+    public async delete(gi: GoalInvocation, classifier: string): Promise<void> {
+        await this.gcs(gi, classifier, async (storage, bucket, cachePath) => storage.bucket(bucket).file(cachePath).delete(), "delete");
+    }
+
+    public async retrieve(gi: GoalInvocation, classifier: string, targetArchivePath: string): Promise<void> {
+        await this.gcs(gi, classifier, async (storage, bucket, cachePath) => storage.bucket(bucket).file(cachePath).download({
+            destination: targetArchivePath,
+        }), "retrieve");
+    }
+
+    private async gcs(gi: GoalInvocation, classifier: string, op: GcsOp, verb: string): Promise<void> {
+        const cacheConfig = getCacheConfig(gi);
+        const cachePath = getCachePath(gi, classifier);
+        const storage = new Storage();
+        const objectUri = `gs://${cacheConfig.bucket}/${cachePath}`;
+        const gerund = verb.replace(/e$/, "ing");
+        try {
+            ll(`${gerund} cache archive ${objectUri}`, gi.progressLog);
+            await op(storage, cacheConfig.bucket, cachePath);
+            ll(`${verb}d cache archive ${objectUri}`, gi.progressLog);
+        } catch (e) {
+            e.message = `Failed to ${verb} cache archive ${objectUri}: ${e.message}`;
+            ll(e.message, gi.progressLog, logger.error);
+            if (verb === "retrieve") {
+                throw e;
+            }
+        }
+    }
+
+}
+
+/** Construct unique object path for goal invocation. */
+export function getCachePath(gi: GoalInvocation, classifier: string = "default"): string {
+    const cacheConfig = getCacheConfig(gi);
+    const cachePath = [
+        cacheConfig.path,
+        gi.context.workspaceId,
+        gi.goalEvent.repo.providerId,
+        gi.goalEvent.repo.owner,
+        gi.goalEvent.repo.name,
+        gi.goalEvent.branch,
+        classifier,
+        `${gi.goalEvent.sha}-cache.tar.gz`,
+    ].join("/");
+    return cachePath;
+}
+
+/**
+ * Retrieve cache configuration and populate with default values.
+ */
+export function getCacheConfig(gi: GoalInvocation): GoogleCloudStorageCacheConfiguration["cache"] {
+    const cacheConfig = gi.configuration.sdm.cache || {};
+    cacheConfig.bucket = cacheConfig.bucket ||
+        `sdm-${gi.context.workspaceId}-${gi.configuration.name}-goal-cache`.toLowerCase().replace(/[^-a-z0-9]*/g, "")
+            .replace(/--+/g, "-");
+    cacheConfig.path = cacheConfig.path || "goal-cache";
+    return cacheConfig;
+}
+
+/** Write to goal progress log and client log. */
+function ll(msg: string, pl: ProgressLog, l: LeveledLogMethod = logger.debug): void {
+    l(msg);
+    pl.write(msg);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1028,6 +1028,140 @@
         }
       }
     },
+    "@google-cloud/common": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@google-cloud/common/-/common-2.0.3.tgz",
+      "integrity": "sha512-1FPOfQ+ZVSRge+wqaWr/6qCa9DWizxJcoZUWegWFTNp9yy3k8WOQsM+C55Ssjivs1TOD5ekEaE4MY9EW5r5vnA==",
+      "requires": {
+        "@google-cloud/projectify": "^1.0.0",
+        "@google-cloud/promisify": "^1.0.0",
+        "@types/request": "^2.48.1",
+        "arrify": "^2.0.0",
+        "duplexify": "^3.6.0",
+        "ent": "^2.2.0",
+        "extend": "^3.0.2",
+        "google-auth-library": "^4.0.0",
+        "retry-request": "^4.0.0",
+        "teeny-request": "^4.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        }
+      }
+    },
+    "@google-cloud/paginator": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-1.0.2.tgz",
+      "integrity": "sha512-mUqsRAJ/OT/Zo/Qh2v+kEeWsEgKZtK4vs2skSiVeudPLwjLSVng+fYZYtLK4kx05OSnm16MqurcPqW14g1/TgQ==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.1",
+        "split-array-stream": "^2.0.0",
+        "stream-events": "^1.0.4"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        }
+      }
+    },
+    "@google-cloud/projectify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-1.0.1.tgz",
+      "integrity": "sha512-xknDOmsMgOYHksKc1GPbwDLsdej8aRNIA17SlSZgQdyrcC0lx0OGo4VZgYfwoEU1YS8oUxF9Y+6EzDOb0eB7Xg=="
+    },
+    "@google-cloud/promisify": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-1.0.2.tgz",
+      "integrity": "sha512-7WfV4R/3YV5T30WRZW0lqmvZy9hE2/p9MvpI34WuKa2Wz62mLu5XplGTFEMK6uTbJCLWUxTcZ4J4IyClKucE5g=="
+    },
+    "@google-cloud/storage": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-3.0.2.tgz",
+      "integrity": "sha512-vIKaTSEpZJkWXUWhAN4wrEisL0JJ6SYjuwWMZKGSit/nRbhAxC8IA82Yrhbm/jI6R9VdBpB+oyHbhQLcMiNJvQ==",
+      "requires": {
+        "@google-cloud/common": "^2.0.0",
+        "@google-cloud/paginator": "^1.0.0",
+        "@google-cloud/promisify": "^1.0.0",
+        "arrify": "^2.0.0",
+        "compressible": "^2.0.12",
+        "concat-stream": "^2.0.0",
+        "date-and-time": "^0.7.0",
+        "duplexify": "^3.5.0",
+        "extend": "^3.0.0",
+        "gaxios": "^2.0.1",
+        "gcs-resumable-upload": "^2.0.0",
+        "hash-stream-validation": "^0.2.1",
+        "mime": "^2.2.0",
+        "mime-types": "^2.0.8",
+        "onetime": "^5.1.0",
+        "p-limit": "^2.2.0",
+        "pumpify": "^1.5.1",
+        "snakeize": "^0.1.0",
+        "stream-events": "^1.0.1",
+        "through2": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        },
+        "concat-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+          "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.0.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        },
+        "mimic-fn": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+          "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+        },
+        "onetime": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
+          "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+          "requires": {
+            "mimic-fn": "^2.1.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        },
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "@heroku-cli/color": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/@heroku-cli/color/-/color-1.1.14.tgz",
@@ -2095,6 +2229,14 @@
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
     },
+    "abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "requires": {
+        "event-target-shim": "^5.0.0"
+      }
+    },
     "accepts": {
       "version": "1.3.7",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.7.tgz",
@@ -3035,6 +3177,11 @@
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
       "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
     },
+    "bignumber.js": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-7.2.1.tgz",
+      "integrity": "sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ=="
+    },
     "binary-extensions": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
@@ -3227,6 +3374,11 @@
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk="
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -3843,6 +3995,14 @@
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
       "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
     },
+    "compressible": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.17.tgz",
+      "integrity": "sha512-BGHeLCK1GV7j1bSmQQAi26X+GgWcTjLr/0tzSvMCl3LH1w1IJ4PFSPoV5316b30cneTziC+B1a+3OjoSUcQYmw==",
+      "requires": {
+        "mime-db": ">= 1.40.0 < 2"
+      }
+    },
     "compromise": {
       "version": "11.13.2",
       "resolved": "https://registry.npmjs.org/compromise/-/compromise-11.13.2.tgz",
@@ -3888,6 +4048,29 @@
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
+    "configstore": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/configstore/-/configstore-5.0.0.tgz",
+      "integrity": "sha512-eE/hvMs7qw7DlcB5JPRnthmrITuHMmACUJAp89v6PT6iOqzoLS7HRWhBtuHMlhNHo2AhUSA/3Dh1bKNJHcublQ==",
+      "requires": {
+        "dot-prop": "^5.1.0",
+        "graceful-fs": "^4.1.2",
+        "make-dir": "^3.0.0",
+        "unique-string": "^2.0.0",
+        "write-file-atomic": "^3.0.0",
+        "xdg-basedir": "^4.0.0"
+      },
+      "dependencies": {
+        "make-dir": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.0.0.tgz",
+          "integrity": "sha512-grNJDhb8b1Jm1qeqW5R/O63wUo4UXo2v2HMic6YT9i/HBlF93S8jkMgH7yugvY9ABDShH4VZMn8I+U8+fCNegw==",
+          "requires": {
+            "semver": "^6.0.0"
+          }
         }
       }
     },
@@ -4020,6 +4203,11 @@
       "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
       "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
+    "crypto-random-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-2.0.0.tgz",
+      "integrity": "sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA=="
+    },
     "cwise-compiler": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/cwise-compiler/-/cwise-compiler-1.1.3.tgz",
@@ -4050,6 +4238,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dasherize/-/dasherize-2.0.0.tgz",
       "integrity": "sha1-bYCcnNDPe7iVLYD8hPoT1H3bEwg="
+    },
+    "date-and-time": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/date-and-time/-/date-and-time-0.7.0.tgz",
+      "integrity": "sha512-qPHBPG0AQqbjP7wVf7vLv25/0bZRjYPiJiJtE0t6RqTswJR/6ExCXQLDnL5w4986j7i6470TMtalJxC8/UHrww=="
     },
     "date-fns": {
       "version": "1.30.1",
@@ -4362,6 +4555,14 @@
         "no-case": "^2.2.0"
       }
     },
+    "dot-prop": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.1.0.tgz",
+      "integrity": "sha512-n1oC6NBF+KM9oVXtjmen4Yo7HyAVWV2UUl50dCYJdw2924K6dX9bf9TTTWaKtYlRn0FEtxG27KS80ayVLixxJA==",
+      "requires": {
+        "is-obj": "^2.0.0"
+      }
+    },
     "dotenv": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
@@ -4412,6 +4613,14 @@
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
+      }
+    },
+    "ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "ee-first": {
@@ -4506,6 +4715,11 @@
         "object-assign": "^4.0.1",
         "tapable": "^0.2.7"
       }
+    },
+    "ent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+      "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0="
     },
     "env-ci": {
       "version": "3.2.2",
@@ -4827,6 +5041,11 @@
         "es5-ext": "~0.10.14"
       }
     },
+    "event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
+    },
     "events": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/events/-/events-2.1.0.tgz",
@@ -5136,6 +5355,11 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
       "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+    },
+    "fast-text-encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.0.tgz",
+      "integrity": "sha512-R9bHCvweUxxwkDwhjav5vxpFvdPGlVngtqmx4pIZfSUhM/Q4NiIUHB456BAf+Q1Nwu3HEZYONtu+Rya+af4jiQ=="
     },
     "fd-slicer": {
       "version": "1.1.0",
@@ -5848,6 +6072,17 @@
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
+    "gaxios": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.0.1.tgz",
+      "integrity": "sha512-c1NXovTxkgRJTIgB2FrFmOFg4YIV6N/bAa4f/FZ4jIw13Ql9ya/82x69CswvotJhbV3DiGnlTZwoq2NVXk2Irg==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.3.0"
+      }
+    },
     "gaze": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
@@ -6270,6 +6505,28 @@
         }
       }
     },
+    "gcp-metadata": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-2.0.1.tgz",
+      "integrity": "sha512-nrbLj5O1MurvpLC/doFwzdTfKnmYGDYXlY/v7eQ4tJNVIvQXbOK672J9UFbradbtmuTkyHzjpzD8HD0Djz0LWw==",
+      "requires": {
+        "gaxios": "^2.0.0",
+        "json-bigint": "^0.3.0"
+      }
+    },
+    "gcs-resumable-upload": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/gcs-resumable-upload/-/gcs-resumable-upload-2.1.1.tgz",
+      "integrity": "sha512-E3fb3yYHbhq0h5lE7oF0AWaYF6oAEszVb05bMAumPCZmd8Ik/ecvDFR0J1nR3EDqDgJ55rw2mIzM2h832XOwFg==",
+      "requires": {
+        "abort-controller": "^3.0.0",
+        "configstore": "^5.0.0",
+        "gaxios": "^2.0.0",
+        "google-auth-library": "^4.0.0",
+        "pumpify": "^1.5.1",
+        "stream-events": "^1.0.4"
+      }
+    },
     "get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -6411,6 +6668,36 @@
         "glob": "~7.1.1",
         "lodash": "~4.17.10",
         "minimatch": "~3.0.2"
+      }
+    },
+    "google-auth-library": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-4.2.5.tgz",
+      "integrity": "sha512-Vfsr82M1KTdT0H0wjawwp0LHsT6mPKSolRp21ZpJ7Ydq63zRe8DbGKjRCCrhsRZHg+p17DuuSCMEznwk3CJRdw==",
+      "requires": {
+        "arrify": "^2.0.0",
+        "base64-js": "^1.3.0",
+        "fast-text-encoding": "^1.0.0",
+        "gaxios": "^2.0.0",
+        "gcp-metadata": "^2.0.0",
+        "gtoken": "^3.0.0",
+        "jws": "^3.1.5",
+        "lru-cache": "^5.0.0"
+      },
+      "dependencies": {
+        "arrify": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+          "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="
+        }
+      }
+    },
+    "google-p12-pem": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.1.tgz",
+      "integrity": "sha512-6h6x+eBX3k+IDSe/c8dVYmn8Mzr1mUcmKC9MdUSwaBkFAXlqBEnwFWmSFgGC+tcqtsLn73BDP/vUNWEehf1Rww==",
+      "requires": {
+        "node-forge": "^0.8.0"
       }
     },
     "got": {
@@ -6736,6 +7023,24 @@
       "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
+    "gtoken": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-3.0.2.tgz",
+      "integrity": "sha512-BOBi6Zz31JfxhSHRZBIDdbwIbOPyux10WxJHdx8wz/FMP1zyN1xFrsAWsgcLe5ww5v/OZu/MePUEZAjgJXSauA==",
+      "requires": {
+        "gaxios": "^2.0.0",
+        "google-p12-pem": "^2.0.0",
+        "jws": "^3.1.5",
+        "mime": "^2.2.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA=="
+        }
+      }
+    },
     "handlebars": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
@@ -6858,6 +7163,14 @@
             "is-buffer": "^1.1.5"
           }
         }
+      }
+    },
+    "hash-stream-validation": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/hash-stream-validation/-/hash-stream-validation-0.2.1.tgz",
+      "integrity": "sha1-7Mm5l7IYvluzEphii7gHhptz3NE=",
+      "requires": {
+        "through2": "^2.0.0"
       }
     },
     "hasha": {
@@ -7167,6 +7480,11 @@
       "requires": {
         "resolve-from": "^3.0.0"
       }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
     },
     "indent-string": {
       "version": "3.2.0",
@@ -7487,6 +7805,11 @@
         }
       }
     },
+    "is-obj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+      "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w=="
+    },
     "is-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
@@ -7551,6 +7874,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-stream-ended": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/is-stream-ended/-/is-stream-ended-0.1.4.tgz",
+      "integrity": "sha512-xj0XPvmr7bQFTvirqnFr50o0hQIh6ZItDqloxt5aJrR4NQsYeSsyFQERYGCAzfindAcnKjINnwEEgLx4IqVzQw=="
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -7717,6 +8045,14 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json-bigint": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.0.tgz",
+      "integrity": "sha1-DM2RLEuCcNBfBW+9E4FLU9OCWx4=",
+      "requires": {
+        "bignumber.js": "^7.0.0"
+      }
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
@@ -7830,6 +8166,25 @@
       "resolved": "https://registry.npmjs.org/jssha/-/jssha-2.3.1.tgz",
       "integrity": "sha1-FHshJTaQNcpLL30hDcU58Amz3po=",
       "dev": true
+    },
+    "jwa": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-1.4.1.tgz",
+      "integrity": "sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==",
+      "requires": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "jws": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
+      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "requires": {
+        "jwa": "^1.4.1",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "keyv": {
       "version": "3.0.0",
@@ -9052,6 +9407,11 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
       "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+    },
+    "node-forge": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.8.5.tgz",
+      "integrity": "sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q=="
     },
     "node-statsd": {
       "version": "0.1.1",
@@ -10447,6 +10807,25 @@
       "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
     },
+    "retry-request": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-4.1.1.tgz",
+      "integrity": "sha512-BINDzVtLI2BDukjWmjAIRZ0oglnCAkpP2vQjM3jdLhmT62h0xnQgciPwBRDAvHqpkPT2Wo1XuUyLyn6nbGrZQQ==",
+      "requires": {
+        "debug": "^4.1.1",
+        "through2": "^3.0.1"
+      },
+      "dependencies": {
+        "through2": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.1.tgz",
+          "integrity": "sha512-M96dvTalPT3YbYLaKaCuwu+j06D/8Jfib0o/PxbVt6Amhv3dUAtW6rTV1jPgJSBG83I/e04Y6xkVdVhSRhi0ww==",
+          "requires": {
+            "readable-stream": "2 || 3"
+          }
+        }
+      }
+    },
     "rimraf": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -10754,6 +11133,11 @@
         "no-case": "^2.2.0"
       }
     },
+    "snakeize": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/snakeize/-/snakeize-0.1.0.tgz",
+      "integrity": "sha1-EMCI2LWOsHazIpu1oE4jLOEmQi0="
+    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -10978,6 +11362,14 @@
         "spdx-ranges": "^2.0.0"
       }
     },
+    "split-array-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/split-array-stream/-/split-array-stream-2.0.0.tgz",
+      "integrity": "sha512-hmMswlVY91WvGMxs0k8MRgq8zb2mSen4FmDNc5AFiTWtrBpdZN6nwD6kROVe4vNL+ywrvbCKsWVCnEd4riELIg==",
+      "requires": {
+        "is-stream-ended": "^0.1.4"
+      }
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -11064,6 +11456,14 @@
       "requires": {
         "duplexer2": "~0.1.0",
         "readable-stream": "^2.0.2"
+      }
+    },
+    "stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "requires": {
+        "stubs": "^3.0.0"
       }
     },
     "stream-shift": {
@@ -11249,6 +11649,11 @@
       "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
       "dev": true
     },
+    "stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha1-6NK6H6nJBXAwPAMLaQD31fiavls="
+    },
     "subarg": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
@@ -11318,6 +11723,16 @@
         "readable-stream": "^2.3.0",
         "to-buffer": "^1.1.1",
         "xtend": "^4.0.0"
+      }
+    },
+    "teeny-request": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-4.0.0.tgz",
+      "integrity": "sha512-Kk87eePsBQZsn5rOIwupObYV7doBMedW3fUOmu3LFVRGEJQ7oeClwWkGFS3nkFs9TFL36qf08vGJd34swMorHQ==",
+      "requires": {
+        "https-proxy-agent": "^2.2.1",
+        "node-fetch": "^2.2.0",
+        "uuid": "^3.3.2"
       }
     },
     "term-size": {
@@ -11749,6 +12164,14 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "typedoc": {
       "version": "0.14.2",
       "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.14.2.tgz",
@@ -11918,6 +12341,14 @@
       "requires": {
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "through2-filter": "^3.0.0"
+      }
+    },
+    "unique-string": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-2.0.0.tgz",
+      "integrity": "sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==",
+      "requires": {
+        "crypto-random-string": "^2.0.0"
       }
     },
     "unist-util-index": {
@@ -12356,6 +12787,17 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "write-file-atomic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
+      "integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
+      "requires": {
+        "imurmurhash": "^0.1.4",
+        "is-typedarray": "^1.0.0",
+        "signal-exit": "^3.0.2",
+        "typedarray-to-buffer": "^3.1.5"
+      }
+    },
     "ws": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.1.0.tgz",
@@ -12373,6 +12815,11 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/x-xss-protection/-/x-xss-protection-1.1.0.tgz",
       "integrity": "sha512-rx3GzJlgEeZ08MIcDsU2vY2B1QEriUKJTSiNHHUIem6eg9pzVOr2TL3Y4Pd6TMAM5D5azGjcxqI62piITBDHVg=="
+    },
+    "xdg-basedir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
+      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q=="
     },
     "xml-js": {
       "version": "1.6.11",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@atomist/sdm-pack-s3": "^0.5.0",
     "@atomist/sdm-pack-spring": "^1.1.1",
     "@atomist/slack-messages": "^1.1.0",
+    "@google-cloud/storage": "^3.0.2",
     "@types/app-root-path": "^1.2.4",
     "@types/fs-extra": "^7.0.0",
     "@types/json-stringify-safe": "^5.0.0",

--- a/test/support/cache.test.ts
+++ b/test/support/cache.test.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright © 2019 Atomist, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { guid } from "@atomist/automation-client";
+import { GoalInvocation } from "@atomist/sdm";
+import { Storage } from "@google-cloud/storage";
+import * as assert from "assert";
+import * as fs from "fs-extra";
+import * as stringify from "json-stringify-safe";
+import * as os from "os";
+import * as path from "path";
+import {
+    getCacheConfig,
+    getCachePath,
+    GoogleCloudStorageGoalCacheArchiveStore,
+} from "../../lib/support/cache";
+
+describe("support/cache", () => {
+
+    describe("getCacheConfig", () => {
+
+        it("should provide default config", () => {
+            const gi: GoalInvocation = {
+                configuration: {
+                    name: "sweetheart-of-the-rodeo",
+                    sdm: {
+                    },
+                },
+                context: {
+                    workspaceId: "TH3BY4D5",
+                },
+            } as any;
+            const c = getCacheConfig(gi);
+            const e = {
+                bucket: "sdm-th3by4d5-sweetheart-of-the-rodeo-goal-cache",
+                path: "goal-cache",
+            };
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should use provided config", () => {
+            const gi: GoalInvocation = {
+                configuration: {
+                    name: "@byrds/sweetheart-of-the-rodeo",
+                    sdm: {
+                        cache: {
+                            bucket: "hickory-wind",
+                            enabled: true,
+                            path: "lazy/days",
+                        },
+                    },
+                },
+                context: {
+                    workspaceId: "TH3BY4D5",
+                },
+            } as any;
+            const c = getCacheConfig(gi);
+            const e = {
+                bucket: "hickory-wind",
+                enabled: true,
+                path: "lazy/days",
+            };
+            assert.deepStrictEqual(c, e);
+        });
+
+        it("should clean up bucket name", () => {
+            const gi: GoalInvocation = {
+                configuration: {
+                    name: "@Sweetheart/of--the-Rodeo-",
+                    sdm: {
+                    },
+                },
+                context: {
+                    workspaceId: "TH3BY4D5",
+                },
+            } as any;
+            const c = getCacheConfig(gi);
+            const e = {
+                bucket: "sdm-th3by4d5-sweetheartof-the-rodeo-goal-cache",
+                path: "goal-cache",
+            };
+            assert.deepStrictEqual(c, e);
+        });
+
+    });
+
+    describe("getCachePath", () => {
+
+        it("should return a reasonable path", () => {
+            const gi: GoalInvocation = {
+                configuration: {
+                    name: "@byrds/sweetheart-of-the-rodeo",
+                    sdm: {
+                        cache: {
+                            bucket: "hickory-wind",
+                            enabled: true,
+                            path: "lazy/days",
+                        },
+                    },
+                },
+                goalEvent: {
+                    branch: "the-christian-life",
+                    repo: {
+                        name: "you-aint-goin-nowhere",
+                        owner: "YoureStillOnMyMind",
+                        providerId: "100yearsfromnow",
+                    },
+                    sha: "808eddb6016a45091e6d53f12ab8ca2d1cd7fb3e",
+                },
+                context: {
+                    workspaceId: "TH3BY4D5",
+                },
+            } as any;
+            const c = "i-am-a-pilgrim";
+            const p = getCachePath(gi, c);
+            // tslint:disable-next-line:max-line-length
+            const e = "lazy/days/TH3BY4D5/100yearsfromnow/YoureStillOnMyMind/you-aint-goin-nowhere/the-christian-life/i-am-a-pilgrim/808eddb6016a45091e6d53f12ab8ca2d1cd7fb3e-cache.tar.gz";
+            assert(p === e);
+        });
+
+    });
+
+    describe("GoogleCloudStorageGoalCacheArchiveStore", () => {
+
+        before(function(): void {
+            if (!process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+                // tslint:disable-next-line:no-invalid-this
+                this.skip();
+            }
+        });
+
+        const tmpDirs: string[] = [];
+        after(async () => {
+            try {
+                await Promise.all(tmpDirs.map(d => fs.remove(d)));
+            } catch (e) { /* ignore */ }
+        });
+
+        it("should store, retrive, and delete a cache item", async () => {
+            const a = new GoogleCloudStorageGoalCacheArchiveStore();
+            const b = "atm-atomist-sdm-goal-cache-production";
+            const p = `test-path-${guid()}`;
+            const gi: GoalInvocation = {
+                configuration: {
+                    name: "@byrds/sweetheart-of-the-rodeo",
+                    sdm: {
+                        cache: {
+                            bucket: b,
+                            enabled: true,
+                            path: p,
+                        },
+                    },
+                },
+                context: {
+                    workspaceId: "WORKSPACEx",
+                },
+                goalEvent: {
+                    branch: "branchx",
+                    repo: {
+                        name: "namex",
+                        owner: "ownerx",
+                        providerId: "providerx",
+                    },
+                    sha: "shax",
+                },
+                progressLog: {
+                    write: ld => { },
+                },
+            } as any;
+            const c = "classifierx";
+            const f = `${p}/WORKSPACEx/providerx/ownerx/namex/branchx/classifierx/shax-cache.tar.gz`;
+            const t = path.join(os.tmpdir(), `atomist-sdm-cache-test-${guid()}`);
+            await fs.ensureDir(t);
+            tmpDirs.push(t);
+            const i = path.join(t, `input-${guid()}.tar.gz`);
+            await fs.writeFile(i, "Test junk\nNot an actual .tar.gz file\n");
+            await a.store(gi, c, i);
+            const s = new Storage();
+            const ie = await s.bucket(b).file(f).exists();
+            assert(ie[0] === true, `Object does not exist: ${stringify(ie)}`);
+            const o = path.join(t, `output-${guid()}.tar.gz`);
+            await a.retrieve(gi, c, o);
+            assert(fs.existsSync(o));
+            const oc = await fs.readFile(o, "utf8");
+            assert(oc === "Test junk\nNot an actual .tar.gz file\n");
+            await a.delete(gi, c);
+            const de = await s.bucket(b).file(f).exists();
+            assert(de[0] === false, `Object does exists after delete: ${stringify(de)}`);
+        }).timeout(20000);
+
+    });
+
+});

--- a/test/support/identityPushTests.test.ts
+++ b/test/support/identityPushTests.test.ts
@@ -22,9 +22,9 @@ import {
 
 describe("identityPushTests", () => {
 
-    describe("isNamed push test", () => {
+    describe("isNamed", () => {
 
-        it("Names itself uniquely for unique input", () => {
+        it("should name itself uniquely for unique input", () => {
             const pt1 = isNamed("Yes", "No");
             const pt2 = isNamed("No");
             assert(pt1.name !== pt2.name, `${pt1.name} = ${pt2.name}`);


### PR DESCRIPTION
Implment GoalCacheArchive for Google Cloud Storage.  Update cache
configuration to use GCS implementation.  Add Google credentials to
k8s deployment spec.  Use caching in web goal sets.

Fix a few bugs around web-site non-default-branch builds and htmltest.

Closes #199